### PR TITLE
Removing test run dependency on the dashboard database

### DIFF
--- a/src/Benchmarks.Framework/BenchmarkTestCaseRunner.cs
+++ b/src/Benchmarks.Framework/BenchmarkTestCaseRunner.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.PlatformAbstractions;
 using XunitDiagnosticMessage = Xunit.DiagnosticMessage;
 using System.Collections.Generic;
 using System.Reflection;
+using Benchmarks.Framework.ResultsLogging;
 
 namespace Benchmarks.Framework
 {
@@ -90,19 +91,12 @@ namespace Benchmarks.Framework
                 runSummary.PopulateMetrics();
                 _diagnosticMessageSink.OnMessage(new XunitDiagnosticMessage(runSummary.ToString()));
 
-                foreach (var database in BenchmarkConfig.Instance.ResultDatabases)
+                var processor = new BenchmarkResultProcessor();
+                processor.SaveSummary(runSummary, BenchmarkConfig.Instance.ResultDatabases, (ex, database) =>
                 {
-                    try
-                    {
-                        new SqlServerBenchmarkResultProcessor(database).SaveSummary(runSummary);
-                    }
-                    catch (Exception ex)
-                    {
-                        _diagnosticMessageSink.OnMessage(
+                    _diagnosticMessageSink.OnMessage(
                             new XunitDiagnosticMessage($"Failed to save results to {database}{Environment.NewLine} {ex}"));
-                        throw;
-                    }
-                }
+                });
             }
 
             return runSummary;

--- a/src/Benchmarks.Framework/ResultsLogging/BenchmarkResultProcessor.cs
+++ b/src/Benchmarks.Framework/ResultsLogging/BenchmarkResultProcessor.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Benchmarks.Framework.ResultsLogging
+{
+    public class BenchmarkResultProcessor
+    {
+        public void SaveSummary(BenchmarkRunSummary summary,
+                                IEnumerable<string> connectionStrings,
+                                Action<Exception, string> exceptionHandler = null,
+                                bool printToConsole = false,
+                                bool onErrorThrow = false,
+                                bool onErrorPrintToConsole = true)
+        {
+            foreach (var database in connectionStrings)
+            {
+                try
+                {
+                    new SqlServerBenchmarkResultProcessor(database).SaveSummary(summary);
+                }
+                catch (Exception ex)
+                {
+                    if (onErrorPrintToConsole)
+                    {
+                        printToConsole = true;
+                    }
+                    exceptionHandler?.Invoke(ex, database);
+                    if (onErrorThrow)
+                    {
+                        throw;
+                    }
+                }
+            }
+            if (printToConsole)
+            {
+                Console.WriteLine(summary.ToString());
+            }
+        }
+    }
+}

--- a/src/Benchmarks.Framework/ResultsLogging/SqlServerBenchmarkResultProcessor.cs
+++ b/src/Benchmarks.Framework/ResultsLogging/SqlServerBenchmarkResultProcessor.cs
@@ -5,7 +5,7 @@ using System;
 using System.Data;
 using System.Data.SqlClient;
 
-namespace Benchmarks.Framework
+namespace Benchmarks.Framework.ResultsLogging
 {
     public class SqlServerBenchmarkResultProcessor
     {

--- a/test/Microsoft.AspNetCore.Tests.Performance/AntaresStartup.cs
+++ b/test/Microsoft.AspNetCore.Tests.Performance/AntaresStartup.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Net.Http;
 using Benchmarks.Framework;
+using Benchmarks.Framework.ResultsLogging;
 using Benchmarks.Utility.Azure;
 using Benchmarks.Utility.Helpers;
 using Microsoft.Extensions.Configuration;
@@ -206,18 +207,11 @@ namespace Microsoft.AspNetCore.Tests.Performance
 
         protected void SaveSummary(ILogger logger)
         {
-            foreach (var database in BenchmarkConfig.Instance.ResultDatabases)
+            var processor = new BenchmarkResultProcessor();
+            processor.SaveSummary(_summary, BenchmarkConfig.Instance.ResultDatabases, (ex, database) =>
             {
-                try
-                {
-                    new SqlServerBenchmarkResultProcessor(database).SaveSummary(_summary);
-                }
-                catch (Exception ex)
-                {
-                    logger.LogError($"Failed to save results to {ex}");
-                    throw;
-                }
-            }
+                logger.LogError($"Failed to save results to {database}{Environment.NewLine} {ex}");
+            });
         }
 
         private static string GetMachineName()

--- a/tools/ThroughputResultReporter/Program.cs
+++ b/tools/ThroughputResultReporter/Program.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Xml.Linq;
 using Benchmarks.Framework;
+using Benchmarks.Framework.ResultsLogging;
 
 namespace ThroughputResultReporter
 {
@@ -55,18 +56,11 @@ namespace ThroughputResultReporter
                     summary.Aggregate(new BenchmarkIterationSummary { TimeElapsed = rps });
                     summary.PopulateMetrics();
 
-                    foreach (var database in BenchmarkConfig.Instance.ResultDatabases)
+                    var processor = new BenchmarkResultProcessor();
+                    processor.SaveSummary(summary, BenchmarkConfig.Instance.ResultDatabases, (ex, database) =>
                     {
-                        try
-                        {
-                            new SqlServerBenchmarkResultProcessor(database).SaveSummary(summary);
-                        }
-                        catch (Exception ex)
-                        {
-                            Console.Error.WriteLine($"Failed to save results to {ex}");
-                            throw;
-                        }
-                    }
+                        Console.Error.WriteLine($"Failed to save results to {database}{Environment.NewLine} {ex}");
+                    });
                 }
             }
         }


### PR DESCRIPTION
The tests can still run, and by default will try to connect to the dashboard database and push the results. However, if the connection fails, the results will simply be printed to screen and the connection failure exception will be handled by an optional user supplied action.

This allows us to maintain compatibility with the current behavior while not getting blocked to run these tests when the dashboard database isn't present. This is also a step forward in running these tests from platforms other than Windows.