### PR TITLE
Initial commit of CI artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: csharp
+sudo: required
+dist: trusty
+addons:
+  apt:
+    packages:
+    - gettext
+    - libcurl4-openssl-dev
+    - libicu-dev
+    - libssl-dev
+    - libunwind8
+    - zlib1g
+mono:
+  - 4.0.5
+os:
+  - linux
+  - osx
+osx_image: xcode7.1
+script:
+  - ./build.sh verify

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ os:
   - osx
 osx_image: xcode7.1
 script:
-  - ./build.sh verify
+  - ./build.sh --quiet verify

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,7 @@
+init:
+  - git config --global core.autocrlf true
+build_script:
+  - build.cmd verify
+clone_depth: 1
+test: off
+deploy: off


### PR DESCRIPTION
These files are used by Travis and Appveyor in order to configure their environment and execute the appropriate build commands.

The files might need tweaking in the future, these are copies of what we're using in other repositories. We'll know if they need changes as our blocking bugs start getting resolved.

This commit brings us closer to completing #33.