### PR TITLE
Benchmark database connectivity check

### DIFF
--- a/src/Benchmarks.Framework/BenchmarkFrameworkInitialization.cs
+++ b/src/Benchmarks.Framework/BenchmarkFrameworkInitialization.cs
@@ -1,0 +1,6 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+[assembly: TestFramework("Benchmarks.Framework.BenchmarkTestFramework", "Benchmarks.Framework")]

--- a/src/Benchmarks.Framework/BenchmarkPersistence/BenchmarkResultProcessor.cs
+++ b/src/Benchmarks.Framework/BenchmarkPersistence/BenchmarkResultProcessor.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Linq;
+
+namespace Benchmarks.Framework.BenchmarkPersistence
+{
+    public static class BenchmarkResultProcessor
+    {
+        private static readonly Lazy<List<string>> GoodConnectionStrings =
+            new Lazy<List<string>>(() => BenchmarkConfig.Instance.ResultDatabases.Where(CanConnect).ToList());
+
+        private static readonly Dictionary<string, SqlServerBenchmarkResultProcessor> Connections =
+            new Dictionary<string, SqlServerBenchmarkResultProcessor>();
+
+        public static void SaveSummary(BenchmarkRunSummary summary)
+        {
+            Console.WriteLine(summary.ToString());
+            foreach (var connectionString in GoodConnectionStrings.Value)
+            {
+                ObtainConnection(connectionString).SaveSummary(summary);
+            }
+        }
+
+        private static bool CanConnect(string connectionString)
+        {
+            var canConnect = false;
+            var csb = new SqlConnectionStringBuilder(connectionString);
+            try
+            {
+                csb.InitialCatalog = "master";
+                var connection = new SqlConnection(csb.ConnectionString);
+                connection.Open();
+                connection.Close();
+                canConnect = true;
+            }
+            catch
+            {
+                Console.Error.WriteLine($"Can't connect to the specified datasource { csb.DataSource }");
+            }
+            return canConnect;
+        }
+
+        private static SqlServerBenchmarkResultProcessor ObtainConnection(string connectionString)
+        {
+            SqlServerBenchmarkResultProcessor result;
+            if (!Connections.TryGetValue(connectionString, out result))
+            {
+                Connections[connectionString] = result = new SqlServerBenchmarkResultProcessor(connectionString);
+            }
+            return result;
+        }
+    }
+}

--- a/src/Benchmarks.Framework/BenchmarkPersistence/BenchmarkResultProcessor.cs
+++ b/src/Benchmarks.Framework/BenchmarkPersistence/BenchmarkResultProcessor.cs
@@ -23,6 +23,7 @@ namespace Benchmarks.Framework.BenchmarkPersistence
 
         internal static void ReleaseInstance()
         {
+            _singleton?.Value?.Dispose();
             _singleton = null;
         }
 

--- a/src/Benchmarks.Framework/BenchmarkPersistence/SqlServerBenchmarkResultProcessor.cs
+++ b/src/Benchmarks.Framework/BenchmarkPersistence/SqlServerBenchmarkResultProcessor.cs
@@ -65,11 +65,8 @@ namespace Benchmarks.Framework.BenchmarkPersistence
         {
             if (disposing)
             {
-                if (_context != null)
-                {
-                    _context.Dispose();
-                    _context = null;
-                }
+                _context?.Dispose();
+                _context = null;
             }
         }
     }

--- a/src/Benchmarks.Framework/BenchmarkPersistence/SqlServerBenchmarkResultProcessor.cs
+++ b/src/Benchmarks.Framework/BenchmarkPersistence/SqlServerBenchmarkResultProcessor.cs
@@ -1,60 +1,75 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Benchmarks.Framework.Model;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Benchmarks.Framework.BenchmarkPersistence
 {
-    public class SqlServerBenchmarkResultProcessor
+    public class SqlServerBenchmarkResultProcessor : IDisposable
     {
-        private readonly string _connectionString;
-        
-        public SqlServerBenchmarkResultProcessor(string connectionString)
-        {
-            _connectionString = connectionString;
-        }
+        private BenchmarkContext _context;
 
-        public void SaveSummary(BenchmarkRunSummary summary)
+        public SqlServerBenchmarkResultProcessor(string connectionString)
         {
             var serviceCollection = new ServiceCollection();
             serviceCollection
                 .AddEntityFramework()
                 .AddSqlServer()
                 .AddDbContext<BenchmarkContext>(
-                    options => options.UseSqlServer(_connectionString));
+                    options => options.UseSqlServer(connectionString));
 
             var serviceProvider = serviceCollection.BuildServiceProvider();
+            _context = serviceProvider.GetRequiredService<BenchmarkContext>();
+            _context.Database.EnsureCreated();
+        }
 
-            using (var context = serviceProvider.GetRequiredService<BenchmarkContext>())
+        public void SaveSummary(BenchmarkRunSummary summary)
+        {
+            _context.Runs.Add(new Run()
             {
-                context.Database.EnsureCreated();
-                context.Runs.Add(new Run()
+                TestClassFullName = summary.TestClassFullName,
+                TestClass = summary.TestClass,
+                TestMethod = summary.TestMethod,
+                Variation = summary.Variation,
+                MachineName = summary.MachineName,
+                ProductReportingVersion = summary.ProductReportingVersion,
+                Framework = summary.Framework,
+                Architecture = summary.Architecture,
+                CustomData = summary.CustomData,
+                RunStarted = summary.RunStarted,
+                WarmupIterations = summary.WarmupIterations,
+                Iterations = summary.Iterations,
+                TimeElapsedAverage = summary.TimeElapsedAverage,
+                TimeElapsedPercentile99 = summary.TimeElapsedPercentile99,
+                TimeElapsedPercentile95 = summary.TimeElapsedPercentile95,
+                TimeElapsedPercentile90 = summary.TimeElapsedPercentile90,
+                MemoryDeltaAverage = summary.MemoryDeltaAverage,
+                MemoryDeltaPercentile99 = summary.MemoryDeltaPercentile99,
+                MemoryDeltaPercentile95 = summary.MemoryDeltaPercentile95,
+                MemoryDeltaPercentile90 = summary.MemoryDeltaPercentile90,
+                MemoryDeltaStandardDeviation = summary.MemoryDeltaStandardDeviation,
+            });
+            _context.SaveChanges();
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (_context != null)
                 {
-                    TestClassFullName = summary.TestClassFullName,
-                    TestClass = summary.TestClass,
-                    TestMethod = summary.TestMethod,
-                    Variation = summary.Variation,
-                    MachineName = summary.MachineName,
-                    ProductReportingVersion = summary.ProductReportingVersion,
-                    Framework = summary.Framework,
-                    Architecture = summary.Architecture,
-                    CustomData = summary.CustomData,
-                    RunStarted = summary.RunStarted,
-                    WarmupIterations = summary.WarmupIterations,
-                    Iterations = summary.Iterations,
-                    TimeElapsedAverage = summary.TimeElapsedAverage,
-                    TimeElapsedPercentile99 = summary.TimeElapsedPercentile99,
-                    TimeElapsedPercentile95 = summary.TimeElapsedPercentile95,
-                    TimeElapsedPercentile90 = summary.TimeElapsedPercentile90,
-                    MemoryDeltaAverage = summary.MemoryDeltaAverage,
-                    MemoryDeltaPercentile99 = summary.MemoryDeltaPercentile99,
-                    MemoryDeltaPercentile95 = summary.MemoryDeltaPercentile95,
-                    MemoryDeltaPercentile90 = summary.MemoryDeltaPercentile90,
-                    MemoryDeltaStandardDeviation = summary.MemoryDeltaStandardDeviation,
-                });
-                context.SaveChanges();
+                    _context.Dispose();
+                    _context = null;
+                }
             }
         }
     }

--- a/src/Benchmarks.Framework/BenchmarkTestCaseRunner.cs
+++ b/src/Benchmarks.Framework/BenchmarkTestCaseRunner.cs
@@ -93,7 +93,7 @@ namespace Benchmarks.Framework
                 
                 try
                 {
-                    BenchmarkResultProcessor.SaveSummary(runSummary);
+                    BenchmarkResultProcessor.Instance.SaveSummary(runSummary);
                 }
                 catch (Exception ex)
                 {

--- a/src/Benchmarks.Framework/BenchmarkTestCaseRunner.cs
+++ b/src/Benchmarks.Framework/BenchmarkTestCaseRunner.cs
@@ -90,19 +90,16 @@ namespace Benchmarks.Framework
             {
                 runSummary.PopulateMetrics();
                 _diagnosticMessageSink.OnMessage(new XunitDiagnosticMessage(runSummary.ToString()));
-
-                foreach (var database in BenchmarkConfig.Instance.ResultDatabases)
+                
+                try
                 {
-                    try
-                    {
-                        new SqlServerBenchmarkResultProcessor(database).SaveSummary(runSummary);
-                    }
-                    catch (Exception ex)
-                    {
-                        _diagnosticMessageSink.OnMessage(
-                            new XunitDiagnosticMessage($"Failed to save results to {database}{Environment.NewLine} {ex}"));
-                        throw;
-                    }
+                    BenchmarkResultProcessor.SaveSummary(runSummary);
+                }
+                catch (Exception ex)
+                {
+                    _diagnosticMessageSink.OnMessage(
+                        new XunitDiagnosticMessage($"Failed to save results {Environment.NewLine} {ex}"));
+                    throw;
                 }
             }
 

--- a/src/Benchmarks.Framework/BenchmarkTestFramework.cs
+++ b/src/Benchmarks.Framework/BenchmarkTestFramework.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Benchmarks.Framework.BenchmarkPersistence;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Benchmarks.Framework
+{
+    public class BenchmarkTestFramework : XunitTestFramework, IDisposable
+    {
+        public BenchmarkTestFramework(IMessageSink messageSink) : base(messageSink) {}
+
+        public new virtual void Dispose()
+        {
+            BenchmarkResultProcessor.ReleaseInstance();
+            base.Dispose();
+        }
+    }
+}

--- a/src/Benchmarks.Framework/project.json
+++ b/src/Benchmarks.Framework/project.json
@@ -12,6 +12,7 @@
     "dnxcore50": {
       "dependencies": {
         "xunit.runner.reporters": "2.1.0",
+        "System.Console": "4.0.0-*",
         "System.Data.SqlClient": "4.0.0-*"
       },
       "imports": "portable-net451+win8"

--- a/test/Microbenchmarks.Tests/project.json
+++ b/test/Microbenchmarks.Tests/project.json
@@ -15,7 +15,7 @@
     "test": "xunit.runner.aspnet"
   },
   "frameworks": {
-    "dnxcore50": { 
+    "dnxcore50": {
       "dependencies": {
         "xunit.runner.aspnet": "2.0.0-aspnet-*"
       },
@@ -27,6 +27,7 @@
       }
     }
   },
+  "compile": "..\\..\\src\\Benchmarks.Framework\\BenchmarkFrameworkInitialization.cs",
   "content": [
     "config.json",
     "xunit.runner.json"

--- a/test/Microsoft.AspNetCore.Tests.Performance/AntaresStartup.cs
+++ b/test/Microsoft.AspNetCore.Tests.Performance/AntaresStartup.cs
@@ -209,7 +209,7 @@ namespace Microsoft.AspNetCore.Tests.Performance
         {
             try
             {
-                BenchmarkResultProcessor.SaveSummary(_summary);
+                BenchmarkResultProcessor.Instance.SaveSummary(_summary);
             }
             catch (Exception ex)
             {

--- a/test/Microsoft.AspNetCore.Tests.Performance/AntaresStartup.cs
+++ b/test/Microsoft.AspNetCore.Tests.Performance/AntaresStartup.cs
@@ -207,17 +207,14 @@ namespace Microsoft.AspNetCore.Tests.Performance
 
         protected void SaveSummary(ILogger logger)
         {
-            foreach (var database in BenchmarkConfig.Instance.ResultDatabases)
+            try
             {
-                try
-                {
-                    new SqlServerBenchmarkResultProcessor(database).SaveSummary(_summary);
-                }
-                catch (Exception ex)
-                {
-                    logger.LogError($"Failed to save results to {database}{Environment.NewLine} {ex}");
-                    throw;
-                }
+                BenchmarkResultProcessor.SaveSummary(_summary);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError($"Failed to save results {Environment.NewLine} {ex}");
+                throw;
             }
         }
 

--- a/test/Microsoft.AspNetCore.Tests.Performance/project.json
+++ b/test/Microsoft.AspNetCore.Tests.Performance/project.json
@@ -26,6 +26,7 @@
   "commands": {
     "test": "xunit.runner.aspnet"
   },
+  "compile": "..\\..\\src\\Benchmarks.Framework\\BenchmarkFrameworkInitialization.cs",
   "content": [
     "config.json",
     "xunit.runner.json"

--- a/test/Microsoft.AspNetCore.Tests.Throughput/project.json
+++ b/test/Microsoft.AspNetCore.Tests.Throughput/project.json
@@ -12,6 +12,7 @@
   "commands": {
     "test": "xunit.runner.aspnet"
   },
+  "compile": "..\\..\\src\\Benchmarks.Framework\\BenchmarkFrameworkInitialization.cs",
   "content": [
     "xunit.runner.json"
   ]

--- a/tools/ThroughputResultReporter/Program.cs
+++ b/tools/ThroughputResultReporter/Program.cs
@@ -58,7 +58,7 @@ namespace ThroughputResultReporter
                     
                     try
                     {
-                        BenchmarkResultProcessor.SaveSummary(summary);
+                        BenchmarkResultProcessor.Instance.SaveSummary(summary);
                     }
                     catch (Exception ex)
                     {

--- a/tools/ThroughputResultReporter/Program.cs
+++ b/tools/ThroughputResultReporter/Program.cs
@@ -55,18 +55,15 @@ namespace ThroughputResultReporter
                     var rps = (long)double.Parse(data["rps"]);
                     summary.Aggregate(new BenchmarkIterationSummary { TimeElapsed = rps });
                     summary.PopulateMetrics();
-
-                    foreach (var database in BenchmarkConfig.Instance.ResultDatabases)
+                    
+                    try
                     {
-                        try
-                        {
-                            new SqlServerBenchmarkResultProcessor(database).SaveSummary(summary);
-                        }
-                        catch (Exception ex)
-                        {
-                            Console.Error.WriteLine($"Failed to save results to {database}{Environment.NewLine} {ex}");
-                            throw;
-                        }
+                        BenchmarkResultProcessor.SaveSummary(summary);
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.Error.WriteLine($"Failed to save results {Environment.NewLine} {ex}");
+                        throw;
                     }
                 }
             }


### PR DESCRIPTION
This enables a very simple level of abstraction where the benchmark result processor takes care of verifying if a connection can be made against a database before proceeding to save the results. This check is only performed once per execution. If a connection can be established, but an error occurs during data insertion, the exception will still pop-up to the caller the same way it has always done.

The change enables the benchmark framework to run without requiring a localdb instance to be available (such as in Linux systems). Tests that don't explicitly ask for a connection to localdb should be able to run everywhere now. This resolves issue #29.

@troydai @NTaylorMullen 