### PR TITLE
Fixes infinite loop in BasicKestrel test

### DIFF
--- a/test/Microsoft.AspNetCore.Tests.Performance/WebPerformance.cs
+++ b/test/Microsoft.AspNetCore.Tests.Performance/WebPerformance.cs
@@ -153,6 +153,7 @@ namespace Microsoft.AspNetCore.Tests.Performance
                 try
                 {
                     File.WriteAllLines(Path.Combine(testProject, "Startup.cs"), lines);
+                    break;
                 }
                 catch (IOException)
                 {


### PR DESCRIPTION
The code tried to write a file and increased a counter when it failed. Retries a max of 3 times, but the successful case wasn't breaking the loop in any way and the test gets stuck re-writing the file forever. This fixes the situation.

/cc @troydai @NTaylorMullen @SajayAntony 