### PR TITLE
Unblocks package restore in OSX

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,6 +7,7 @@ nugetPath=$buildFolder/nuget.exe
 
 if test `uname` = Darwin; then
     cachedir=~/Library/Caches/KBuild
+    ulimit -n 1024
 else
     if [ -z $XDG_DATA_HOME ]; then
         cachedir=$HOME/.local/share


### PR DESCRIPTION
This is just a temporary workaround for dotnet/cli#809. We can revert it once the issue is fixed.