### PR TITLE
Kestrel with pooling

### DIFF
--- a/Performance.sln
+++ b/Performance.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24711.0
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{39290E57-4492-4F65-89D6-64C95DE73976}"
 EndProject
@@ -67,6 +67,8 @@ EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "RazorCodeGenerator", "testapp\RazorCodeGenerator\RazorCodeGenerator.xproj", "{0236230D-D34D-4546-9221-E5767F19ED9E}"
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "TestApp.Test", "test\TestApp.Test\TestApp.Test.xproj", "{82B767A5-1640-4561-9F04-2E90AD0BDEFB}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "PooledKestrel", "testapp\PooledKestrel\PooledKestrel.xproj", "{F14C584D-3175-43B8-996F-59046629CD27}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -170,6 +172,10 @@ Global
 		{82B767A5-1640-4561-9F04-2E90AD0BDEFB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{82B767A5-1640-4561-9F04-2E90AD0BDEFB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{82B767A5-1640-4561-9F04-2E90AD0BDEFB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F14C584D-3175-43B8-996F-59046629CD27}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F14C584D-3175-43B8-996F-59046629CD27}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F14C584D-3175-43B8-996F-59046629CD27}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F14C584D-3175-43B8-996F-59046629CD27}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -199,5 +205,6 @@ Global
 		{67598949-B2F2-4E43-8D89-431712978A48} = {93AB896C-D117-4DBB-9DB1-24903022E21B}
 		{0236230D-D34D-4546-9221-E5767F19ED9E} = {93AB896C-D117-4DBB-9DB1-24903022E21B}
 		{82B767A5-1640-4561-9F04-2E90AD0BDEFB} = {39290E57-4492-4F65-89D6-64C95DE73976}
+		{F14C584D-3175-43B8-996F-59046629CD27} = {93AB896C-D117-4DBB-9DB1-24903022E21B}
 	EndGlobalSection
 EndGlobal

--- a/testapp/PooledKestrel/PooledHttpContext.cs
+++ b/testapp/PooledKestrel/PooledHttpContext.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Http.Internal;
+
+namespace Microsoft.AspNetCore.Test.Perf.WebFx.Apps.LowAlloc
+{
+    public class PooledHttpContext : DefaultHttpContext
+    {
+        DefaultHttpRequest _pooledHttpRequest;
+        DefaultHttpResponse _pooledHttpResponse;
+
+        public PooledHttpContext(IFeatureCollection featureCollection) :
+            base(featureCollection)
+        {
+        }
+
+        protected override HttpRequest InitializeHttpRequest()
+        {
+            if (_pooledHttpRequest != null)
+            {
+                _pooledHttpRequest.Initialize(this);
+                return _pooledHttpRequest;
+            }
+
+            return new DefaultHttpRequest(this);
+        }
+
+        protected override void UninitializeHttpRequest(HttpRequest instance)
+        {
+            _pooledHttpRequest = instance as DefaultHttpRequest;
+            _pooledHttpRequest?.Uninitialize();
+        }
+
+        protected override HttpResponse InitializeHttpResponse()
+        {
+            if (_pooledHttpResponse != null)
+            {
+                _pooledHttpResponse.Initialize(this);
+                return _pooledHttpResponse;
+            }
+
+            return new DefaultHttpResponse(this);
+        }
+
+        protected override void UninitializeHttpResponse(HttpResponse instance)
+        {
+            _pooledHttpResponse = instance as DefaultHttpResponse;
+            _pooledHttpResponse?.Uninitialize();
+        }
+    }
+}

--- a/testapp/PooledKestrel/PooledHttpContextFactory.cs
+++ b/testapp/PooledKestrel/PooledHttpContextFactory.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Concurrent;
+using System.Globalization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.AspNetCore.Test.Perf.WebFx.Apps.LowAlloc
+{
+    public class PooledHttpContextFactory : IHttpContextFactory
+    {
+        private readonly int _maxPooledContexts;
+        private readonly ConcurrentQueue<PooledHttpContext> _pool = new ConcurrentQueue<PooledHttpContext>();
+
+        public PooledHttpContextFactory(IConfiguration configuration)
+        {
+            _maxPooledContexts = GetPooledCount(configuration["hosting.maxPooledContexts"]);
+        }
+
+        public HttpContext Create(IFeatureCollection featureCollection)
+        {
+            PooledHttpContext httpContext = null;
+            if (_pool.TryDequeue(out httpContext))
+            {
+                httpContext.Initialize(featureCollection);
+            }
+            else
+            {
+                httpContext = new PooledHttpContext(featureCollection);
+            }
+
+            return httpContext;
+        }
+
+        public void Dispose(HttpContext httpContext)
+        {
+            var pooled = httpContext as PooledHttpContext;
+            if (pooled != null)
+            {
+                // approximation due to race condition on count
+                if (_pool.Count < _maxPooledContexts)
+                {
+                    pooled.Uninitialize();
+                    _pool.Enqueue(pooled);
+                }
+            }
+        }
+
+        private static int GetPooledCount(string countString)
+        {
+            if (string.IsNullOrEmpty(countString))
+            {
+                return 0;
+            }
+
+            int count;
+            if (int.TryParse(countString, NumberStyles.Integer, CultureInfo.InvariantCulture, out count))
+            {
+                return count > 0 ? count : 0;
+            }
+
+            return 0;
+        }
+    }
+}

--- a/testapp/PooledKestrel/PooledKestrel.xproj
+++ b/testapp/PooledKestrel/PooledKestrel.xproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="__ToolsVersion__" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>f14c584d-3175-43b8-996f-59046629cd27</ProjectGuid>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'" Label="Configuration">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'" Label="Configuration">
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/testapp/PooledKestrel/Startup.cs
+++ b/testapp/PooledKestrel/Startup.cs
@@ -1,0 +1,54 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Text;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNetCore.Test.Perf.WebFx.Apps.LowAlloc
+{
+    public class Startup
+    {
+        private static readonly byte[] _helloWorldPayload = Encoding.UTF8.GetBytes("Hello, World!");
+        private static IConfiguration _configuration;
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddSingleton(typeof(IHttpContextFactory), typeof(PooledHttpContextFactory));
+            services.AddSingleton(typeof(IConfiguration), _configuration);
+        }
+
+        public void Configure(IApplicationBuilder app)
+        {
+            app.Run(context =>
+            {
+                context.Response.StatusCode = 200;
+                context.Response.ContentType = "text/plain";
+                // HACK: Setting the Content-Length header manually avoids the cost of serializing the int to a string.
+                //       This is instead of: httpContext.Response.ContentLength = _helloWorldPayload.Length;
+                context.Response.Headers["Content-Length"] = "13";
+                return context.Response.Body.WriteAsync(_helloWorldPayload, 0, _helloWorldPayload.Length);
+            });
+        }
+
+        public static void Main(string[] args)
+        {
+            _configuration = new ConfigurationBuilder()
+                .AddJsonFile("hosting.json", optional: true)
+                .Build();
+
+            var host = new WebHostBuilder()
+                .UseServer("Microsoft.AspNetCore.Server.Kestrel")
+                .UseDefaultConfiguration(args)
+                .UseConfiguration(_configuration)
+                .UseIISPlatformHandlerUrl()
+                .UseStartup<Startup>()
+                .Build();
+
+            host.Run();
+        }
+    }
+}

--- a/testapp/PooledKestrel/hosting.json
+++ b/testapp/PooledKestrel/hosting.json
@@ -1,0 +1,5 @@
+﻿{
+  "hosting.maxPooledContexts": 256,
+  "kestrel.maxPooledStreams": 256,
+  "kestrel.maxPooledHeaders": 256
+}

--- a/testapp/PooledKestrel/loadtest.ps1
+++ b/testapp/PooledKestrel/loadtest.ps1
@@ -1,0 +1,5 @@
+param([int] $iterations = 1000000)
+
+$url = "http://127.0.0.1:5000"
+
+& loadtest -k -n $iterations -c 128  $url

--- a/testapp/PooledKestrel/project.json
+++ b/testapp/PooledKestrel/project.json
@@ -1,0 +1,20 @@
+{
+  "version": "1.0.0",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "frameworks": {
+    "dnxcore50": { },
+    "dnx451": { }
+  },
+  "dependencies": {
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
+    "Microsoft.AspNetCore.IISPlatformHandler": "1.0.0-*",
+    "Microsoft.NETCore.Platforms": "1.0.1-*",
+    "Microsoft.Extensions.Configuration": "1.0.0-*",
+    "Microsoft.Extensions.Configuration.Json": "1.0.0-*"
+  },
+  "commands": {
+    "web": "PooledKestrel"
+  }
+}

--- a/testapp/PooledKestrel/readme.md
+++ b/testapp/PooledKestrel/readme.md
@@ -1,0 +1,12 @@
+The pooling levels are controled by the settings in `hosting.json`
+
+If the values are not present they are set to zero which means no pooling; this is the default
+
+`kestrel.maxPooledStreams` - how many Response+Request+Duplex stream objects Kestrel will at max have pooled
+`kestrel.maxPooledHeaders` - how many Response+Request header objects Kestrel will at max have pooled
+
+It also has a `PooledHttpContext` and `PooledHttpContextFactory` in the project, which pool the `DefaultHttpRequest` and `DefaultHttpResponse` objects
+
+The pooling of the HttpContext checks the following setting
+
+`hosting.maxPooledContexts` which is the maximum number that will be pooled

--- a/testapp/PooledKestrel/wwwroot/README.txt
+++ b/testapp/PooledKestrel/wwwroot/README.txt
@@ -1,0 +1,1 @@
+﻿This file is here to keep wwwroot directory which is required for correct publish


### PR DESCRIPTION
Regular 3671 MB, 21.1 million objects per 1M requests

![regular](http://aoa.blob.core.windows.net/aspnet/non-pooled-a.png)

Current max pooling 428 MB, 9.3 million objects per 1M requests

![pooled](http://aoa.blob.core.windows.net/aspnet/pooled.png)

Note the header allocations in regular is a recent change https://github.com/aspnet/KestrelHttpServer/pull/608 as they are no longer by default pooled on a connection.

*Aside:* A connection can be shared by many users behind a reverse forwarder; so if you don't like the "risk of pooling"; probably shouldn't share stuff at the connection level