### PR TITLE
Adding test skip condition support

### DIFF
--- a/src/Benchmarks.Framework/project.json
+++ b/src/Benchmarks.Framework/project.json
@@ -5,6 +5,7 @@
     "Microsoft.Extensions.Configuration.Json": "1.0.0-*",
     "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0-*",
     "Microsoft.Extensions.PlatformAbstractions": "1.0.0-*",
+    "Microsoft.AspNetCore.Testing": "1.0.0-*",
     "Microsoft.NETCore.Platforms": "1.0.1-*",
     "xunit": "2.1.0"
   },

--- a/test/Microbenchmarks.Tests/HostingTests.cs
+++ b/test/Microbenchmarks.Tests/HostingTests.cs
@@ -7,14 +7,16 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Xunit;
 
 namespace Microbenchmarks.Tests
 {
     public class HostingTests : BenchmarkTestBase
     {
+        [OSSkipCondition(OperatingSystems.MacOSX)]
+        [OSSkipCondition(OperatingSystems.Linux)]
         [Benchmark]
         [BenchmarkVariation("Kestrel", "Microsoft.AspNetCore.Server.Kestrel")]
         [BenchmarkVariation("WebListener", "Microsoft.AspNetCore.Server.WebListener")]

--- a/test/Microbenchmarks.Tests/project.json
+++ b/test/Microbenchmarks.Tests/project.json
@@ -7,7 +7,8 @@
     "Microsoft.AspNetCore.Server.WebListener": "0.1.0-*",
     "Microsoft.AspNetCore.Mvc": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc.TagHelpers": "1.0.0-*",
-    "Microsoft.AspNetCore.TestHost": "1.0.0-*"
+    "Microsoft.AspNetCore.TestHost": "1.0.0-*",
+    "Microsoft.AspNetCore.Testing": "1.0.0-*"
   },
   "testRunner": "xunit",
   "commands": {


### PR DESCRIPTION
Adding test skip condition support. We're also skipping test MainToConfigureOverhead when not in Windows.

This solves #61 

@muratg @NTaylorMullen @troydai 