### PR TITLE
Update project.json for every projects to use NETStandard.Library

### DIFF
--- a/testapp/BasicKestrel/project.json
+++ b/testapp/BasicKestrel/project.json
@@ -4,13 +4,16 @@
     "emitEntryPoint": true
   },
   "frameworks": {
-    "dnxcore50": { },
+    "dnxcore50": {
+      "dependencies": {
+        "NETStandard.Library": "1.0.0-*"
+      }
+    },
     "dnx451": { }
   },
   "dependencies": {
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
-    "Microsoft.AspNetCore.IISPlatformHandler": "1.0.0-*",
-    "Microsoft.NETCore.Platforms": "1.0.1-*"
+    "Microsoft.AspNetCore.IISPlatformHandler": "1.0.0-*"
   },
   "commands": {
     "web": "BasicKestrel"

--- a/testapp/BasicKestrelJson/project.json
+++ b/testapp/BasicKestrelJson/project.json
@@ -4,14 +4,17 @@
     "emitEntryPoint": true
   },
   "frameworks": {
-    "dnxcore50": { },
+    "dnxcore50": {
+      "dependencies": {
+        "NETStandard.Library": "1.0.0-*"
+      }
+    },
     "dnx451": { }
   },
   "dependencies": {
     "Newtonsoft.Json": "8.0.2",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
-    "Microsoft.AspNetCore.IISPlatformHandler": "1.0.0-*",
-    "Microsoft.NETCore.Platforms": "1.0.1-*"
+    "Microsoft.AspNetCore.IISPlatformHandler": "1.0.0-*"
   },
   "commands": {
     "web": "BasicKestrelJson"

--- a/testapp/BasicViews/project.json
+++ b/testapp/BasicViews/project.json
@@ -12,8 +12,7 @@
     "Microsoft.AspNetCore.Mvc.TagHelpers": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.AspNetCore.Server.WebListener": "0.1.0-*",
-    "Microsoft.AspNetCore.StaticFiles": "1.0.0-*",
-    "Microsoft.NETCore.Platforms": "1.0.1-*"
+    "Microsoft.AspNetCore.StaticFiles": "1.0.0-*"
   },
 
   "commands": {
@@ -23,6 +22,9 @@
   "frameworks": {
     "dnx451": { },
     "dnxcore50": {
+      "dependencies": {
+        "NETStandard.Library": "1.0.0-*"
+      },
       "imports": "portable-net451+win8"
     }
   },

--- a/testapp/BigModelBinding/project.json
+++ b/testapp/BigModelBinding/project.json
@@ -9,8 +9,7 @@
   "dependencies": {
     "Microsoft.AspNetCore.Mvc": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
-    "Microsoft.AspNetCore.Server.WebListener": "0.1.0-*",
-    "Microsoft.NETCore.Platforms": "1.0.1-*"
+    "Microsoft.AspNetCore.Server.WebListener": "0.1.0-*"
   },
 
   "commands": {
@@ -25,7 +24,7 @@
     },
     "dnxcore50": {
       "dependencies": {
-        "System.ComponentModel.Annotations": "4.0.11-*"
+        "NETStandard.Library": "1.0.0-*"
       },
       "imports": "portable-net451+win8"
     }

--- a/testapp/BigViews/project.json
+++ b/testapp/BigViews/project.json
@@ -11,8 +11,7 @@
     "Microsoft.AspNetCore.IISPlatformHandler": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc.TagHelpers": "1.0.0-*",
-    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
-    "Microsoft.NETCore.Platforms": "1.0.1-*"
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*"
   },
 
   "commands": {
@@ -22,6 +21,9 @@
   "frameworks": {
     "dnx451": { },
     "dnxcore50": {
+      "dependencies": {
+        "NETStandard.Library": "1.0.0-*"
+      },
       "imports": "portable-net451+win8"
     }
   },

--- a/testapp/HelloWorldMvc/project.json
+++ b/testapp/HelloWorldMvc/project.json
@@ -6,6 +6,9 @@
   },
   "frameworks": {
     "dnxcore50": {
+      "dependencies": {
+        "NETStandard.Library": "1.0.0-*"
+      },
       "imports": "portable-net451+win8"
       },
     "dnx451": {}
@@ -13,8 +16,7 @@
   "dependencies": {
     "Microsoft.AspNetCore.Mvc": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
-    "Microsoft.AspNetCore.IISPlatformHandler": "1.0.0-*",
-    "Microsoft.NETCore.Platforms": "1.0.1-*"
+    "Microsoft.AspNetCore.IISPlatformHandler": "1.0.0-*"
   },
   "commands": {
     "web": "HelloWorldMvc"

--- a/testapp/LargePageMvc/project.json
+++ b/testapp/LargePageMvc/project.json
@@ -6,15 +6,17 @@
   },
   "frameworks": {
     "dnxcore50": {
-      "imports": "portable-net451+win8"
+      "dependencies": {
+        "NETStandard.Library": "1.0.0-*"
       },
+      "imports": "portable-net451+win8"
+    },
     "dnx451": {}
   },
   "dependencies": {
     "Microsoft.AspNetCore.Mvc": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
-    "Microsoft.AspNetCore.IISPlatformHandler": "1.0.0-*",
-    "Microsoft.NETCore.Platforms": "1.0.1-*"
+    "Microsoft.AspNetCore.IISPlatformHandler": "1.0.0-*"
   },
   "commands": {
     "web": "LargePageMvc"

--- a/testapp/LargeStaticView/project.json
+++ b/testapp/LargeStaticView/project.json
@@ -10,8 +10,7 @@
   "dependencies": {
     "Microsoft.AspNetCore.Mvc": "1.0.0-*",
     "Microsoft.AspNetCore.Mvc.TagHelpers": "1.0.0-*",
-    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
-    "Microsoft.NETCore.Platforms": "1.0.1-*"
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*"
   },
 
   "commands": {
@@ -21,6 +20,9 @@
   "frameworks": {
     "dnx451": {},
     "dnxcore50": {
+      "dependencies": {
+        "NETStandard.Library": "1.0.0-*"
+      },
       "imports": "portable-net451+win8"
     }
   },

--- a/testapp/LocalizedViews/project.json
+++ b/testapp/LocalizedViews/project.json
@@ -12,8 +12,7 @@
     "Microsoft.AspNetCore.Mvc.TagHelpers": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.AspNetCore.Server.WebListener": "0.1.0-*",
-    "Microsoft.AspNetCore.StaticFiles": "1.0.0-*",
-    "Microsoft.NETCore.Platforms": "1.0.1-*"
+    "Microsoft.AspNetCore.StaticFiles": "1.0.0-*"
   },
 
   "commands": {
@@ -23,6 +22,9 @@
   "frameworks": {
     "dnx451": { },
     "dnxcore50": {
+      "dependencies": {
+        "NETStandard.Library": "1.0.0-*"
+      },
       "imports": "portable-net451+win8"
     }
   },

--- a/testapp/MediumApi/project.json
+++ b/testapp/MediumApi/project.json
@@ -12,7 +12,6 @@
     "Microsoft.AspNetCore.Mvc.Formatters.Json": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.AspNetCore.Server.WebListener": "0.1.0-*",
-    "Microsoft.NETCore.Platforms": "1.0.1-*",
     "Newtonsoft.Json": "8.0.2"
   },
 
@@ -23,6 +22,9 @@
   "frameworks": {
     "dnx451": {},
     "dnxcore50": {
+      "dependencies": {
+        "NETStandard.Library": "1.0.0-*"
+      },
       "imports": "portable-net451+win8"
     }
   },

--- a/testapp/PlainTextMvc/project.json
+++ b/testapp/PlainTextMvc/project.json
@@ -5,6 +5,9 @@
   },
   "frameworks": {
     "dnxcore50": {
+      "dependencies": {
+        "NETStandard.Library": "1.0.0-*"
+      },
       "imports": "portable-net451+win8"
     },
     "dnx451": {}
@@ -12,8 +15,7 @@
   "dependencies": {
     "Microsoft.AspNetCore.Mvc": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
-    "Microsoft.AspNetCore.IISPlatformHandler": "1.0.0-*",
-    "Microsoft.NETCore.Platforms": "1.0.1-*"
+    "Microsoft.AspNetCore.IISPlatformHandler": "1.0.0-*"
   },
   "commands": {
     "web": "PlainTextMvc"

--- a/testapp/PooledKestrel/project.json
+++ b/testapp/PooledKestrel/project.json
@@ -4,13 +4,16 @@
     "emitEntryPoint": true
   },
   "frameworks": {
-    "dnxcore50": { },
+    "dnxcore50": {
+      "dependencies": {
+        "NETStandard.Library": "1.0.0-*"
+      }
+    },
     "dnx451": { }
   },
   "dependencies": {
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.AspNetCore.IISPlatformHandler": "1.0.0-*",
-    "Microsoft.NETCore.Platforms": "1.0.1-*",
     "Microsoft.Extensions.Configuration": "1.0.0-*",
     "Microsoft.Extensions.Configuration.Json": "1.0.0-*"
   },

--- a/testapp/RazorCodeGenerator/project.json
+++ b/testapp/RazorCodeGenerator/project.json
@@ -6,8 +6,7 @@
   },
 
   "dependencies": {
-    "Microsoft.AspNetCore.Mvc.Razor": "1.0.0-*",
-    "Microsoft.NETCore.Platforms": "1.0.1-*"
+    "Microsoft.AspNetCore.Mvc.Razor": "1.0.0-*"
   },
 
   "commands": {
@@ -17,6 +16,9 @@
   "frameworks": {
     "dnx451": {},
     "dnxcore50": {
+      "dependencies": {
+        "NETStandard.Library": "1.0.0-*"
+      },
       "imports": "portable-net451+win8"
     }
   }

--- a/testapp/StarterMvc/project.json
+++ b/testapp/StarterMvc/project.json
@@ -16,7 +16,6 @@
     "Microsoft.AspNetCore.Mvc.TagHelpers": "1.0.0-*",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
     "Microsoft.AspNetCore.StaticFiles": "1.0.0-*",
-    "Microsoft.NETCore.Platforms": "1.0.1-*",
     "Microsoft.Extensions.Configuration.FileProviderExtensions": "1.0.0-*",
     "Microsoft.Extensions.Configuration.Json": "1.0.0-*",
     "Microsoft.Extensions.Configuration.UserSecrets": "1.0.0-*",
@@ -35,6 +34,9 @@
   "frameworks": {
     "dnx451": { },
     "dnxcore50": {
+      "dependencies": {
+        "NETStandard.Library": "1.0.0-*"
+      },
       "imports": "portable-net451+win8"
     }
   },


### PR DESCRIPTION
New standard: Use NETStandard.Library to establish dependency to NETCore package 