### PR TITLE
Large file multipart POST test

### DIFF
--- a/testapp/MultipartPOST/Baseline_DesktopCLR_MVC5_MultipartPOST/App_Start/FilterConfig.cs
+++ b/testapp/MultipartPOST/Baseline_DesktopCLR_MVC5_MultipartPOST/App_Start/FilterConfig.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Web.Mvc;
+
+namespace MultipartPOST
+{
+    public class FilterConfig
+    {
+        public static void RegisterGlobalFilters(GlobalFilterCollection filters)
+        {
+            filters.Add(new HandleErrorAttribute());
+        }
+    }
+}

--- a/testapp/MultipartPOST/Baseline_DesktopCLR_MVC5_MultipartPOST/App_Start/IdentityConfig.cs
+++ b/testapp/MultipartPOST/Baseline_DesktopCLR_MVC5_MultipartPOST/App_Start/IdentityConfig.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Identity;
+using Microsoft.AspNet.Identity.EntityFramework;
+using Microsoft.AspNet.Identity.Owin;
+using Microsoft.Owin;
+using MultipartPOST.Models;
+
+namespace MultipartPOST
+{
+    // Configure the application user manager used in this application. UserManager is defined in ASP.NET Identity and is used by the application.
+
+    public class ApplicationUserManager : UserManager<ApplicationUser>
+    {
+        public ApplicationUserManager(IUserStore<ApplicationUser> store)
+            : base(store)
+        {
+        }
+
+        public static ApplicationUserManager Create(IdentityFactoryOptions<ApplicationUserManager> options, IOwinContext context)
+        {
+            var manager = new ApplicationUserManager(new UserStore<ApplicationUser>(context.Get<ApplicationDbContext>()));
+            // Configure validation logic for usernames
+            manager.UserValidator = new UserValidator<ApplicationUser>(manager)
+            {
+                AllowOnlyAlphanumericUserNames = false,
+                RequireUniqueEmail = true
+            };
+            // Configure validation logic for passwords
+            manager.PasswordValidator = new PasswordValidator
+            {
+                RequiredLength = 6,
+                RequireNonLetterOrDigit = true,
+                RequireDigit = true,
+                RequireLowercase = true,
+                RequireUppercase = true,
+            };
+            var dataProtectionProvider = options.DataProtectionProvider;
+            if (dataProtectionProvider != null)
+            {
+                manager.UserTokenProvider = new DataProtectorTokenProvider<ApplicationUser>(dataProtectionProvider.Create("ASP.NET Identity"));
+            }
+            return manager;
+        }
+    }
+}

--- a/testapp/MultipartPOST/Baseline_DesktopCLR_MVC5_MultipartPOST/App_Start/RouteConfig.cs
+++ b/testapp/MultipartPOST/Baseline_DesktopCLR_MVC5_MultipartPOST/App_Start/RouteConfig.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Web.Mvc;
+using System.Web.Routing;
+
+namespace MultipartPOST
+{
+    public class RouteConfig
+    {
+        public static void RegisterRoutes(RouteCollection routes)
+        {
+            routes.IgnoreRoute("{resource}.axd/{*pathInfo}");
+
+            routes.MapRoute(
+                name: "Default",
+                url: "{controller}/{action}/{id}",
+                defaults: new { controller = "Home", action = "Index", id = UrlParameter.Optional }
+            );
+        }
+    }
+}

--- a/testapp/MultipartPOST/Baseline_DesktopCLR_MVC5_MultipartPOST/App_Start/Startup.Auth.cs
+++ b/testapp/MultipartPOST/Baseline_DesktopCLR_MVC5_MultipartPOST/App_Start/Startup.Auth.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNet.Identity;
+using Microsoft.Owin;
+using Microsoft.Owin.Security.Cookies;
+using Microsoft.Owin.Security.OAuth;
+using MultipartPOST.Models;
+using MultipartPOST.Providers;
+using Owin;
+
+namespace MultipartPOST
+{
+    public partial class Startup
+    {
+        public static OAuthAuthorizationServerOptions OAuthOptions { get; private set; }
+
+        public static string PublicClientId { get; private set; }
+
+        // For more information on configuring authentication, please visit http://go.microsoft.com/fwlink/?LinkId=301864
+        public void ConfigureAuth(IAppBuilder app)
+        {
+            // Configure the db context and user manager to use a single instance per request
+            app.CreatePerOwinContext(ApplicationDbContext.Create);
+            app.CreatePerOwinContext<ApplicationUserManager>(ApplicationUserManager.Create);
+
+            // Enable the application to use a cookie to store information for the signed in user
+            // and to use a cookie to temporarily store information about a user logging in with a third party login provider
+            app.UseCookieAuthentication(new CookieAuthenticationOptions());
+            app.UseExternalSignInCookie(DefaultAuthenticationTypes.ExternalCookie);
+
+            // Configure the application for OAuth based flow
+            PublicClientId = "self";
+            OAuthOptions = new OAuthAuthorizationServerOptions
+            {
+                TokenEndpointPath = new PathString("/Token"),
+                Provider = new ApplicationOAuthProvider(PublicClientId),
+                AuthorizeEndpointPath = new PathString("/api/Account/ExternalLogin"),
+                AccessTokenExpireTimeSpan = TimeSpan.FromDays(14),
+                // In production mode set AllowInsecureHttp = false
+                AllowInsecureHttp = true
+            };
+
+            // Enable the application to use bearer tokens to authenticate users
+            app.UseOAuthBearerTokens(OAuthOptions);
+
+            // Uncomment the following lines to enable logging in with third party login providers
+            //app.UseMicrosoftAccountAuthentication(
+            //    clientId: "",
+            //    clientSecret: "");
+
+            //app.UseTwitterAuthentication(
+            //    consumerKey: "",
+            //    consumerSecret: "");
+
+            //app.UseFacebookAuthentication(
+            //    appId: "",
+            //    appSecret: "");
+
+            //app.UseGoogleAuthentication(new GoogleOAuth2AuthenticationOptions()
+            //{
+            //    ClientId = "",
+            //    ClientSecret = ""
+            //});
+        }
+    }
+}

--- a/testapp/MultipartPOST/Baseline_DesktopCLR_MVC5_MultipartPOST/App_Start/WebApiConfig.cs
+++ b/testapp/MultipartPOST/Baseline_DesktopCLR_MVC5_MultipartPOST/App_Start/WebApiConfig.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Web.Http;
+using Microsoft.Owin.Security.OAuth;
+
+namespace MultipartPOST
+{
+    public static class WebApiConfig
+    {
+        public static void Register(HttpConfiguration config)
+        {
+            // Web API configuration and services
+            // Configure Web API to use only bearer token authentication.
+            config.SuppressDefaultHostAuthentication();
+            config.Filters.Add(new HostAuthenticationFilter(OAuthDefaults.AuthenticationType));
+
+            // Web API routes
+            config.MapHttpAttributeRoutes();
+
+            config.Routes.MapHttpRoute(
+                name: "Upload",
+                routeTemplate: "api/upload",
+                defaults: new { controller = "Upload", id = RouteParameter.Optional }
+            );
+
+            config.Routes.MapHttpRoute(
+                name: "DefaultApi",
+                routeTemplate: "api/{controller}/{id}",
+                defaults: new { id = RouteParameter.Optional }
+            );
+        }
+    }
+}

--- a/testapp/MultipartPOST/Baseline_DesktopCLR_MVC5_MultipartPOST/Controllers/HomeController.cs
+++ b/testapp/MultipartPOST/Baseline_DesktopCLR_MVC5_MultipartPOST/Controllers/HomeController.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Web.Mvc;
+
+namespace MultipartPOST.Controllers
+{
+    public class HomeController : Controller
+    {
+        public ActionResult Index()
+        {
+            return View();
+        }
+    }
+}

--- a/testapp/MultipartPOST/Baseline_DesktopCLR_MVC5_MultipartPOST/Controllers/UploadController.cs
+++ b/testapp/MultipartPOST/Baseline_DesktopCLR_MVC5_MultipartPOST/Controllers/UploadController.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Web;
+using System.Web.Http;
+
+namespace MultipartPOST.Controllers
+{
+    [Route("api/upload")]
+    public class UploadController : ApiController
+    {
+        public async Task<IHttpActionResult> Post()
+        {
+            if (!Request.Content.IsMimeMultipartContent())
+            {
+                return BadRequest("Expecting a multi-part content type for the Upload POST command");
+            }
+
+            Console.WriteLine("Processing a POST request to /api/upload");
+
+            var appDataDirectory = HttpContext.Current.Server.MapPath("~/App_Data");
+            if (!Directory.Exists(appDataDirectory))
+            {
+                try
+                {
+                    Directory.CreateDirectory(appDataDirectory);
+                }
+                catch
+                {
+                    // ignore
+                }
+            }
+            var provider = new MultipartFormDataStreamProvider(appDataDirectory);
+            try
+            {
+                await Request.Content.ReadAsMultipartAsync(provider);
+            }
+            catch (Exception e)
+            {
+                return InternalServerError(e);
+            }
+            
+            foreach (var fileData in provider.FileData)
+            {
+                File.Delete(fileData.LocalFileName);
+            }
+
+            Console.WriteLine("Done");
+
+            return Ok();
+        }
+    }
+}

--- a/testapp/MultipartPOST/Baseline_DesktopCLR_MVC5_MultipartPOST/Global.asax
+++ b/testapp/MultipartPOST/Baseline_DesktopCLR_MVC5_MultipartPOST/Global.asax
@@ -1,0 +1,1 @@
+﻿<%@ Application Codebehind="Global.asax.cs" Inherits="MultipartPOST.WebApiApplication" Language="C#" %>

--- a/testapp/MultipartPOST/Baseline_DesktopCLR_MVC5_MultipartPOST/Global.asax.cs
+++ b/testapp/MultipartPOST/Baseline_DesktopCLR_MVC5_MultipartPOST/Global.asax.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Web.Http;
+using System.Web.Mvc;
+using System.Web.Routing;
+
+namespace MultipartPOST
+{
+    public class WebApiApplication : System.Web.HttpApplication
+    {
+        protected void Application_Start()
+        {
+            AreaRegistration.RegisterAllAreas();
+            GlobalConfiguration.Configure(WebApiConfig.Register);
+            FilterConfig.RegisterGlobalFilters(GlobalFilters.Filters);
+            RouteConfig.RegisterRoutes(RouteTable.Routes);
+        }
+    }
+}

--- a/testapp/MultipartPOST/Baseline_DesktopCLR_MVC5_MultipartPOST/Models/IdentityModels.cs
+++ b/testapp/MultipartPOST/Baseline_DesktopCLR_MVC5_MultipartPOST/Models/IdentityModels.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNet.Identity;
+using Microsoft.AspNet.Identity.EntityFramework;
+
+namespace MultipartPOST.Models
+{
+    // You can add profile data for the user by adding more properties to your ApplicationUser class, please visit http://go.microsoft.com/fwlink/?LinkID=317594 to learn more.
+    public class ApplicationUser : IdentityUser
+    {
+        public async Task<ClaimsIdentity> GenerateUserIdentityAsync(UserManager<ApplicationUser> manager, string authenticationType)
+        {
+            // Note the authenticationType must match the one defined in CookieAuthenticationOptions.AuthenticationType
+            var userIdentity = await manager.CreateIdentityAsync(this, authenticationType);
+            // Add custom user claims here
+            return userIdentity;
+        }
+    }
+
+    public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
+    {
+        public ApplicationDbContext()
+            : base("DefaultConnection", throwIfV1Schema: false)
+        {
+        }
+
+        public static ApplicationDbContext Create()
+        {
+            return new ApplicationDbContext();
+        }
+    }
+}

--- a/testapp/MultipartPOST/Baseline_DesktopCLR_MVC5_MultipartPOST/MultipartPOST-MVC5.csproj
+++ b/testapp/MultipartPOST/Baseline_DesktopCLR_MVC5_MultipartPOST/MultipartPOST-MVC5.csproj
@@ -1,0 +1,245 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.0\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props" Condition="Exists('..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.0\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" />
+  <Import Project="..\packages\Microsoft.Net.Compilers.1.0.0\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.1.0.0\build\Microsoft.Net.Compilers.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>
+    </ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{6ED905F2-CD62-4F98-A9FE-E2DFA8F664DA}</ProjectGuid>
+    <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>MultipartPOST</RootNamespace>
+    <AssemblyName>MultipartPOST</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <MvcBuildViews>false</MvcBuildViews>
+    <UseIISExpress>true</UseIISExpress>
+    <IISExpressSSLPort />
+    <IISExpressAnonymousAuthentication />
+    <IISExpressWindowsAuthentication />
+    <IISExpressUseClassicPipelineMode />
+    <UseGlobalApplicationHostFile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.0\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Web.Entity" />
+    <Reference Include="System.Web.ApplicationServices" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Web.Abstractions" />
+    <Reference Include="System.Web.Routing" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http">
+    </Reference>
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.WebRequest">
+    </Reference>
+    <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.Helpers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http.WebHost, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.WebHost.5.2.3\lib\net45\System.Web.Http.WebHost.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Mvc, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.AspNet.Mvc.5.2.3\lib\net45\System.Web.Mvc.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Optimization">
+      <HintPath>..\packages\Microsoft.AspNet.Web.Optimization.1.1.3\lib\net40\System.Web.Optimization.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.AspNet.Razor.3.2.3\lib\net45\System.Web.Razor.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages.Deployment, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.Deployment.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
+    </Reference>
+    <Reference Include="WebGrease">
+      <Private>True</Private>
+      <HintPath>..\packages\WebGrease.1.5.2\lib\WebGrease.dll</HintPath>
+    </Reference>
+    <Reference Include="Antlr3.Runtime">
+      <Private>True</Private>
+      <HintPath>..\packages\Antlr.3.4.1.9004\lib\Antlr3.Runtime.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="EntityFramework">
+      <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="EntityFramework.SqlServer">
+      <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNet.Identity.Core">
+      <HintPath>..\packages\Microsoft.AspNet.Identity.Core.2.2.1\lib\net45\Microsoft.AspNet.Identity.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNet.Identity.Owin">
+      <HintPath>..\packages\Microsoft.AspNet.Identity.Owin.2.2.1\lib\net45\Microsoft.AspNet.Identity.Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNet.Identity.EntityFramework">
+      <HintPath>..\packages\Microsoft.AspNet.Identity.EntityFramework.2.2.1\lib\net45\Microsoft.AspNet.Identity.EntityFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Owin">
+      <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin">
+      <HintPath>..\packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Host.SystemWeb">
+      <HintPath>..\packages\Microsoft.Owin.Host.SystemWeb.3.0.1\lib\net45\Microsoft.Owin.Host.SystemWeb.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Security">
+      <HintPath>..\packages\Microsoft.Owin.Security.3.0.1\lib\net45\Microsoft.Owin.Security.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Security.Facebook">
+      <HintPath>..\packages\Microsoft.Owin.Security.Facebook.3.0.1\lib\net45\Microsoft.Owin.Security.Facebook.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Security.Cookies">
+      <HintPath>..\packages\Microsoft.Owin.Security.Cookies.3.0.1\lib\net45\Microsoft.Owin.Security.Cookies.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Security.OAuth">
+      <HintPath>..\packages\Microsoft.Owin.Security.OAuth.3.0.1\lib\net45\Microsoft.Owin.Security.OAuth.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Security.Google">
+      <HintPath>..\packages\Microsoft.Owin.Security.Google.3.0.1\lib\net45\Microsoft.Owin.Security.Google.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Security.Twitter">
+      <HintPath>..\packages\Microsoft.Owin.Security.Twitter.3.0.1\lib\net45\Microsoft.Owin.Security.Twitter.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Security.MicrosoftAccount">
+      <HintPath>..\packages\Microsoft.Owin.Security.MicrosoftAccount.3.0.1\lib\net45\Microsoft.Owin.Security.MicrosoftAccount.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http.Owin">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Owin.5.2.3\lib\net45\System.Web.Http.Owin.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="App_Start\FilterConfig.cs" />
+    <Compile Include="App_Start\IdentityConfig.cs" />
+    <Compile Include="App_Start\RouteConfig.cs" />
+    <Compile Include="App_Start\Startup.Auth.cs" />
+    <Compile Include="App_Start\WebApiConfig.cs" />
+    <Compile Include="Controllers\HomeController.cs" />
+    <Compile Include="Controllers\UploadController.cs" />
+    <Compile Include="Global.asax.cs">
+      <DependentUpon>Global.asax</DependentUpon>
+    </Compile>
+    <Compile Include="Models\IdentityModels.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Providers\ApplicationOAuthProvider.cs" />
+    <Compile Include="Startup.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Global.asax" />
+    <Content Include="Web.config" />
+    <Content Include="Web.Debug.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </Content>
+    <Content Include="Web.Release.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </Content>
+    <Content Include="Views\Home\Index.cshtml" />
+  </ItemGroup>
+  <ItemGroup />
+  <ItemGroup>
+    <Content Include="packages.config" />
+  </ItemGroup>
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
+  <Target Name="MvcBuildViews" AfterTargets="AfterBuild" Condition="'$(MvcBuildViews)'=='true'">
+    <AspNetCompiler VirtualPath="temp" PhysicalPath="$(WebProjectOutputDir)" />
+  </Target>
+  <ProjectExtensions>
+    <VisualStudio>
+      <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
+        <WebProjectProperties>
+          <UseIIS>True</UseIIS>
+          <AutoAssignPort>True</AutoAssignPort>
+          <DevelopmentServerPort>28070</DevelopmentServerPort>
+          <DevelopmentServerVPath>/</DevelopmentServerVPath>
+          <IISUrl>http://localhost:28070/</IISUrl>
+          <NTLMAuthentication>False</NTLMAuthentication>
+          <UseCustomServer>False</UseCustomServer>
+          <CustomServerUrl>
+          </CustomServerUrl>
+          <SaveServerSettingsInUserFile>False</SaveServerSettingsInUserFile>
+        </WebProjectProperties>
+      </FlavorProperties>
+    </VisualStudio>
+  </ProjectExtensions>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.1.0.0\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.1.0.0\build\Microsoft.Net.Compilers.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.0\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.0\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target> -->
+</Project>

--- a/testapp/MultipartPOST/Baseline_DesktopCLR_MVC5_MultipartPOST/Properties/AssemblyInfo.cs
+++ b/testapp/MultipartPOST/Baseline_DesktopCLR_MVC5_MultipartPOST/Properties/AssemblyInfo.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("MultipartPOST")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("MultipartPOST")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("15991c56-54d7-45c4-b997-420aa738894a")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Revision and Build Numbers
+// by using the '*' as shown below:
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/testapp/MultipartPOST/Baseline_DesktopCLR_MVC5_MultipartPOST/Providers/ApplicationOAuthProvider.cs
+++ b/testapp/MultipartPOST/Baseline_DesktopCLR_MVC5_MultipartPOST/Providers/ApplicationOAuthProvider.cs
@@ -1,0 +1,98 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNet.Identity.Owin;
+using Microsoft.Owin.Security;
+using Microsoft.Owin.Security.Cookies;
+using Microsoft.Owin.Security.OAuth;
+using MultipartPOST.Models;
+
+namespace MultipartPOST.Providers
+{
+    public class ApplicationOAuthProvider : OAuthAuthorizationServerProvider
+    {
+        private readonly string _publicClientId;
+
+        public ApplicationOAuthProvider(string publicClientId)
+        {
+            if (publicClientId == null)
+            {
+                throw new ArgumentNullException("publicClientId");
+            }
+
+            _publicClientId = publicClientId;
+        }
+
+        public override async Task GrantResourceOwnerCredentials(OAuthGrantResourceOwnerCredentialsContext context)
+        {
+            var userManager = context.OwinContext.GetUserManager<ApplicationUserManager>();
+
+            ApplicationUser user = await userManager.FindAsync(context.UserName, context.Password);
+
+            if (user == null)
+            {
+                context.SetError("invalid_grant", "The user name or password is incorrect.");
+                return;
+            }
+
+            ClaimsIdentity oAuthIdentity = await user.GenerateUserIdentityAsync(userManager,
+               OAuthDefaults.AuthenticationType);
+            ClaimsIdentity cookiesIdentity = await user.GenerateUserIdentityAsync(userManager,
+                CookieAuthenticationDefaults.AuthenticationType);
+
+            AuthenticationProperties properties = CreateProperties(user.UserName);
+            AuthenticationTicket ticket = new AuthenticationTicket(oAuthIdentity, properties);
+            context.Validated(ticket);
+            context.Request.Context.Authentication.SignIn(cookiesIdentity);
+        }
+
+        public override Task TokenEndpoint(OAuthTokenEndpointContext context)
+        {
+            foreach (KeyValuePair<string, string> property in context.Properties.Dictionary)
+            {
+                context.AdditionalResponseParameters.Add(property.Key, property.Value);
+            }
+
+            return Task.FromResult<object>(null);
+        }
+
+        public override Task ValidateClientAuthentication(OAuthValidateClientAuthenticationContext context)
+        {
+            // Resource owner password credentials does not provide a client ID.
+            if (context.ClientId == null)
+            {
+                context.Validated();
+            }
+
+            return Task.FromResult<object>(null);
+        }
+
+        public override Task ValidateClientRedirectUri(OAuthValidateClientRedirectUriContext context)
+        {
+            if (context.ClientId == _publicClientId)
+            {
+                Uri expectedRootUri = new Uri(context.Request.Uri, "/");
+
+                if (expectedRootUri.AbsoluteUri == context.RedirectUri)
+                {
+                    context.Validated();
+                }
+            }
+
+            return Task.FromResult<object>(null);
+        }
+
+        public static AuthenticationProperties CreateProperties(string userName)
+        {
+            IDictionary<string, string> data = new Dictionary<string, string>
+            {
+                { "userName", userName }
+            };
+            return new AuthenticationProperties(data);
+        }
+    }
+}

--- a/testapp/MultipartPOST/Baseline_DesktopCLR_MVC5_MultipartPOST/Startup.cs
+++ b/testapp/MultipartPOST/Baseline_DesktopCLR_MVC5_MultipartPOST/Startup.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Owin;
+using Owin;
+
+[assembly: OwinStartup(typeof(MultipartPOST.Startup))]
+
+namespace MultipartPOST
+{
+    public partial class Startup
+    {
+        public void Configuration(IAppBuilder app)
+        {
+            ConfigureAuth(app);
+        }
+    }
+}

--- a/testapp/MultipartPOST/Baseline_DesktopCLR_MVC5_MultipartPOST/Views/Home/Index.cshtml
+++ b/testapp/MultipartPOST/Baseline_DesktopCLR_MVC5_MultipartPOST/Views/Home/Index.cshtml
@@ -1,0 +1,2 @@
+﻿@inherits System.Web.Mvc.WebViewPage
+Home loaded successfully.

--- a/testapp/MultipartPOST/Baseline_DesktopCLR_MVC5_MultipartPOST/Web.Debug.config
+++ b/testapp/MultipartPOST/Baseline_DesktopCLR_MVC5_MultipartPOST/Web.Debug.config
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0"?>
+
+<!-- For more information on using Web.config transformation visit http://go.microsoft.com/fwlink/?LinkId=301874 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--
+    In the example below, the "SetAttributes" transform will change the value of
+    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator
+    finds an attribute "name" that has a value of "MyDB".
+
+    <connectionStrings>
+      <add name="MyDB"
+        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True"
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    </connectionStrings>
+  -->
+  <system.web>
+    <!--
+      In the example below, the "Replace" transform will replace the entire
+      <customErrors> section of your Web.config file.
+      Note that because there is only one customErrors section under the
+      <system.web> node, there is no need to use the "xdt:Locator" attribute.
+
+      <customErrors defaultRedirect="GenericError.htm"
+        mode="RemoteOnly" xdt:Transform="Replace">
+        <error statusCode="500" redirect="InternalError.htm"/>
+      </customErrors>
+    -->
+  </system.web>
+</configuration>

--- a/testapp/MultipartPOST/Baseline_DesktopCLR_MVC5_MultipartPOST/Web.Release.config
+++ b/testapp/MultipartPOST/Baseline_DesktopCLR_MVC5_MultipartPOST/Web.Release.config
@@ -1,0 +1,31 @@
+﻿<?xml version="1.0"?>
+
+<!-- For more information on using Web.config transformation visit http://go.microsoft.com/fwlink/?LinkId=301874 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--
+    In the example below, the "SetAttributes" transform will change the value of
+    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator
+    finds an attribute "name" that has a value of "MyDB".
+
+    <connectionStrings>
+      <add name="MyDB"
+        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True"
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    </connectionStrings>
+  -->
+  <system.web>
+    <compilation xdt:Transform="RemoveAttributes(debug)" />
+    <!--
+      In the example below, the "Replace" transform will replace the entire
+      <customErrors> section of your Web.config file.
+      Note that because there is only one customErrors section under the
+      <system.web> node, there is no need to use the "xdt:Locator" attribute.
+
+      <customErrors defaultRedirect="GenericError.htm"
+        mode="RemoteOnly" xdt:Transform="Replace">
+        <error statusCode="500" redirect="InternalError.htm"/>
+      </customErrors>
+    -->
+  </system.web>
+</configuration>

--- a/testapp/MultipartPOST/Baseline_DesktopCLR_MVC5_MultipartPOST/Web.config
+++ b/testapp/MultipartPOST/Baseline_DesktopCLR_MVC5_MultipartPOST/Web.config
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  For more information on how to configure your ASP.NET application, please visit
+  http://go.microsoft.com/fwlink/?LinkId=301879
+  -->
+<configuration>
+  <configSections>
+    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
+    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+  </configSections>
+  <connectionStrings>
+    <add name="DefaultConnection" connectionString="Data Source=(LocalDb)\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\aspnet-MultipartPOST-20160225125406.mdf;Initial Catalog=aspnet-MultipartPOST-20160225125406;Integrated Security=True"
+      providerName="System.Data.SqlClient" />
+  </connectionStrings>
+  <appSettings></appSettings>
+  <system.web>
+    <authentication mode="None" />
+    <compilation debug="true" targetFramework="4.5.2" />
+    <httpRuntime targetFramework="4.5.2" maxRequestLength="2097152" />
+  </system.web>
+  <system.webServer>
+    <security>
+      <requestFiltering>
+        <requestLimits maxAllowedContentLength="2147483648" />
+      </requestFiltering>
+    </security>
+    <modules>
+      <remove name="FormsAuthentication" />
+    </modules>
+    <handlers>
+      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
+      <remove name="OPTIONSVerbHandler" />
+      <remove name="TRACEVerbHandler" />
+      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+    </handlers>
+  </system.webServer>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.1.0" newVersion="3.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin.Security.OAuth" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.1.0" newVersion="3.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin.Security.Cookies" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.1.0" newVersion="3.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.1.0" newVersion="3.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="0.0.0.0-1.5.2.14234" newVersion="1.5.2.14234" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+  <entityFramework>
+    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework" />
+    <providers>
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+    </providers>
+  </entityFramework>
+  <system.codedom>
+    <compilers>
+      <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:6 /nowarn:1659;1699;1701" />
+      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:14 /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
+    </compilers>
+  </system.codedom>
+</configuration>

--- a/testapp/MultipartPOST/Baseline_DesktopCLR_MVC5_MultipartPOST/packages.config
+++ b/testapp/MultipartPOST/Baseline_DesktopCLR_MVC5_MultipartPOST/packages.config
@@ -1,0 +1,39 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Antlr" version="3.4.1.9004" targetFramework="net452" />
+  <package id="bootstrap" version="3.0.0" targetFramework="net452" />
+  <package id="EntityFramework" version="6.1.3" targetFramework="net452" />
+  <package id="jQuery" version="1.10.2" targetFramework="net452" />
+  <package id="jQuery.Validation" version="1.11.1" targetFramework="net452" />
+  <package id="Microsoft.AspNet.Identity.Core" version="2.2.1" targetFramework="net452" />
+  <package id="Microsoft.AspNet.Identity.EntityFramework" version="2.2.1" targetFramework="net452" />
+  <package id="Microsoft.AspNet.Identity.Owin" version="2.2.1" targetFramework="net452" />
+  <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net452" />
+  <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net452" />
+  <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net452" />
+  <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net452" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net452" />
+  <package id="Microsoft.AspNet.WebApi.HelpPage" version="5.2.3" targetFramework="net452" />
+  <package id="Microsoft.AspNet.WebApi.Owin" version="5.2.3" targetFramework="net452" />
+  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net452" />
+  <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net452" />
+  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.0" targetFramework="net452" />
+  <package id="Microsoft.jQuery.Unobtrusive.Validation" version="3.2.3" targetFramework="net452" />
+  <package id="Microsoft.Net.Compilers" version="1.0.0" targetFramework="net452" developmentDependency="true" />
+  <package id="Microsoft.Owin" version="3.0.1" targetFramework="net452" />
+  <package id="Microsoft.Owin.Host.SystemWeb" version="3.0.1" targetFramework="net452" />
+  <package id="Microsoft.Owin.Security" version="3.0.1" targetFramework="net452" />
+  <package id="Microsoft.Owin.Security.Cookies" version="3.0.1" targetFramework="net452" />
+  <package id="Microsoft.Owin.Security.Facebook" version="3.0.1" targetFramework="net452" />
+  <package id="Microsoft.Owin.Security.Google" version="3.0.1" targetFramework="net452" />
+  <package id="Microsoft.Owin.Security.MicrosoftAccount" version="3.0.1" targetFramework="net452" />
+  <package id="Microsoft.Owin.Security.OAuth" version="3.0.1" targetFramework="net452" />
+  <package id="Microsoft.Owin.Security.Twitter" version="3.0.1" targetFramework="net452" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net452" />
+  <package id="Modernizr" version="2.6.2" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net452" />
+  <package id="Owin" version="1.0" targetFramework="net452" />
+  <package id="Respond" version="1.2.0" targetFramework="net452" />
+  <package id="WebGrease" version="1.5.2" targetFramework="net452" />
+</packages>

--- a/testapp/MultipartPOST/MultipartPOST.sln
+++ b/testapp/MultipartPOST/MultipartPOST.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.24720.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "MultipartPOST", "MultipartPOST\MultipartPOST.xproj", "{E5D2EE3F-672A-41A5-9B0B-0A979E333920}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "MultipartPOSTClient", "MultipartPOSTClient\MultipartPOSTClient.xproj", "{B44BCA57-E0F1-494E-84A2-FA4D8491C9B1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MultipartPOST-MVC5", "Baseline_DesktopCLR_MVC5_MultipartPOST\MultipartPOST-MVC5.csproj", "{6ED905F2-CD62-4F98-A9FE-E2DFA8F664DA}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E5D2EE3F-672A-41A5-9B0B-0A979E333920}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E5D2EE3F-672A-41A5-9B0B-0A979E333920}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E5D2EE3F-672A-41A5-9B0B-0A979E333920}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E5D2EE3F-672A-41A5-9B0B-0A979E333920}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B44BCA57-E0F1-494E-84A2-FA4D8491C9B1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B44BCA57-E0F1-494E-84A2-FA4D8491C9B1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B44BCA57-E0F1-494E-84A2-FA4D8491C9B1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B44BCA57-E0F1-494E-84A2-FA4D8491C9B1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6ED905F2-CD62-4F98-A9FE-E2DFA8F664DA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6ED905F2-CD62-4F98-A9FE-E2DFA8F664DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6ED905F2-CD62-4F98-A9FE-E2DFA8F664DA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6ED905F2-CD62-4F98-A9FE-E2DFA8F664DA}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/testapp/MultipartPOST/MultipartPOST/Controllers/HomeController.cs
+++ b/testapp/MultipartPOST/MultipartPOST/Controllers/HomeController.cs
@@ -1,0 +1,15 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc;
+
+namespace MultipartPost.Controllers
+{
+    public class HomeController : Controller
+    {
+        public IActionResult Index()
+        {
+            return View();
+        }
+    }
+}

--- a/testapp/MultipartPOST/MultipartPOST/Controllers/UploadController.cs
+++ b/testapp/MultipartPOST/MultipartPOST/Controllers/UploadController.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.WebUtilities;
+
+namespace MultipartPost.Controllers
+{
+    [Route("api/upload")]
+    public class UploadController : Controller
+    {
+        private const int DefaultBufferSize = 4096;
+
+        public async Task<IActionResult> Post()
+        {
+            if (!HasMultipartFormContentType(Request.ContentType))
+            {
+                return BadRequest("Expecting a multipart content type for the Upload POST command");
+            }
+
+            PrintLine("Processing a POST request to /api/upload");
+
+            var buffer = new byte[DefaultBufferSize];
+            var boundary = GetBoundary(Request.ContentType);
+            var reader = new MultipartReader(boundary, Request.Body);
+            while (true)
+            {
+                var section = await reader.ReadNextSectionAsync();
+                if (section == null)
+                {
+                    break;
+                }
+                PrintLine("Reading section");
+                PrintLine($"Content-Disposition:{ section.ContentDisposition }");
+                long bytesRead = 0;
+                //try reading the entire message
+                while (true)
+                {
+                    var length = section.Body.Read(buffer, 0, buffer.Length);
+                    if (length <= 0) break;
+                    bytesRead += length;
+                }
+                PrintLine($"Read { bytesRead } bytes");
+            }
+
+            PrintLine("Done");
+
+            return Ok();
+        }
+
+        private static bool HasMultipartFormContentType(string contentType)
+        {
+            return contentType != null && contentType.StartsWith("multipart/", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string GetBoundary(string contentType)
+        {
+            var elements = contentType.Split(' ');
+            var element = elements.First(entry => entry.StartsWith("boundary="));
+            var boundary = element.Substring("boundary=".Length);
+            // Remove quotes if present
+            if (boundary.Length >= 2 && boundary[0] == '"' && boundary[boundary.Length - 1] == '"')
+            {
+                boundary = boundary.Substring(1, boundary.Length - 2);
+            }
+            return boundary;
+        }
+
+        private void PrintLine(string input, params object[] paramStrings)
+        {
+            Console.Write($"[{ DateTime.UtcNow.ToString(CultureInfo.InvariantCulture) }] ");
+            Console.WriteLine(input, paramStrings);
+        }
+    }
+}

--- a/testapp/MultipartPOST/MultipartPOST/MultipartPOST.xproj
+++ b/testapp/MultipartPOST/MultipartPOST/MultipartPOST.xproj
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0.24720" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.24720</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>e5d2ee3f-672a-41a5-9b0b-0a979e333920</ProjectGuid>
+    <RootNamespace>MultipartPost</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/testapp/MultipartPOST/MultipartPOST/Startup.cs
+++ b/testapp/MultipartPOST/MultipartPOST/Startup.cs
@@ -1,0 +1,44 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MultipartPost
+{
+    public class Startup
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddMvc();
+        }
+
+        public void Configure(IApplicationBuilder app)
+        {
+            app.UseIISPlatformHandler();
+
+            app.UseMvc(routes =>
+            {
+                routes.MapRoute(
+                    name: "default",
+                    template: "{controller=Home}/{action=Index}/{id?}");
+            });
+        }
+
+        public static void Main(string[] args)
+        {
+            Console.WriteLine($"Running in { IntPtr.Size * 8 } bits");
+
+            var host = new WebHostBuilder()
+                .UseServer("Microsoft.AspNetCore.Server.Kestrel")
+                .UseDefaultConfiguration(args)
+                .UseIISPlatformHandlerUrl()
+                .UseStartup<Startup>()
+                .Build();
+
+            host.Run();
+        }
+    }
+}

--- a/testapp/MultipartPOST/MultipartPOST/Views/Home/Index.cshtml
+++ b/testapp/MultipartPOST/MultipartPOST/Views/Home/Index.cshtml
@@ -1,0 +1,1 @@
+﻿Home loaded successfully.

--- a/testapp/MultipartPOST/MultipartPOST/project.json
+++ b/testapp/MultipartPOST/MultipartPOST/project.json
@@ -1,0 +1,22 @@
+{
+  "version": "1.0.0",
+  "compilationOptions": {
+    "emitEntryPoint": true,
+    "preserveCompilationContext": true
+  },
+  "frameworks": {
+    "dnxcore50": {
+      "imports": "portable-net451+win8"
+      }
+  },
+  "dependencies": {
+    "Microsoft.AspNetCore.Mvc": "1.0.0-*",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
+    "Microsoft.AspNetCore.IISPlatformHandler": "1.0.0-*",
+    "NETStandard.Library": "1.0.0-*"
+  },
+  "commands": {
+    "web": "MultipartPOST"
+  },
+  "content": ["Views"]
+}

--- a/testapp/MultipartPOST/MultipartPOST/wwwroot/README.txt
+++ b/testapp/MultipartPOST/MultipartPOST/wwwroot/README.txt
@@ -1,0 +1,1 @@
+﻿This file is here to keep wwwroot directory which is required for correct publish

--- a/testapp/MultipartPOST/MultipartPOST/wwwroot/web.config
+++ b/testapp/MultipartPOST/MultipartPOST/wwwroot/web.config
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <!--system.web>
+    <httpRuntime maxRequestLength="2097152" />
+  </system.web-->
+  <system.webServer>
+    <!--security>
+      <requestFiltering>
+        <requestLimits maxAllowedContentLength="2147483648" />
+      </requestFiltering>
+    </security-->
+    <handlers>
+      <add name="httpPlatformHandler" path="*" verb="*" modules="httpPlatformHandler" resourceType="Unspecified" />
+    </handlers>
+    <httpPlatform processPath="%DNX_PATH%" arguments="%DNX_ARGS%" forwardWindowsAuthToken="false" startupTimeLimit="3600" />
+</system.webServer>
+</configuration>

--- a/testapp/MultipartPOST/MultipartPOSTClient/MultipartPOSTClient.xproj
+++ b/testapp/MultipartPOST/MultipartPOSTClient/MultipartPOSTClient.xproj
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0.24720" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.24720</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>b44bca57-e0f1-494e-84a2-fa4d8491c9b1</ProjectGuid>
+    <RootNamespace>MultipartPostClient</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/testapp/MultipartPOST/MultipartPOSTClient/Program.cs
+++ b/testapp/MultipartPOST/MultipartPOSTClient/Program.cs
@@ -1,0 +1,187 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+
+namespace MultipartPostClient
+{
+    public class Program
+    {
+        private const long OneByte = 1;
+        private const long OneKilobyte = OneByte * 1024;
+        private const long OneMegabyte = OneKilobyte * 1024;
+        private const long OneGigabyte = OneMegabyte * 1024;
+
+        private static string _apiEndpoint = "http://localhost:5000/";
+
+        private static readonly Random Random = new Random(DateTime.UtcNow.Millisecond);
+
+        public static void Main(string[] args)
+        {
+            if (args?.Length > 0)
+            {
+                _apiEndpoint = args[0];
+            }
+
+            var bits = IntPtr.Size * 8;
+            PrintLine($"Running in { bits } bits");
+            PrintLine($"Target endpoint is { _apiEndpoint }");
+
+            PrintLine("Start");
+            try
+            {
+                var program = new Program();
+                program.WarmupConnection().Wait();
+
+                for (var i = 1; i < 10; ++i)
+                {
+                    PrintLine($"Iteration { i }");
+
+                    // Scenario 1: Small text part + large text part: 10MB/100MB/1GB [5:3:1]
+                    PrintLine("Scenario 1");
+                    program.SendLoad(program.Scenario1FileContentGenerator).Wait();
+
+                    // Scenario 2: Small text part + large binary part: 10MB/100MB/1GB [5:3:1]
+                    PrintLine("Scenario 2");
+                    program.SendLoad(program.Scenario2FileContentGenerator).Wait();
+
+                    if (bits >= 64)
+                    {
+                        // Scenario 3: A number of large parts: text/binary [2:1] totalling more than 4GB (to test 32-bit limit)
+                        PrintLine("Scenario 3");
+                        program.SendLoad(program.Scenario3FileContentGenerator, 4).Wait();
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Console.Error.WriteLine(e.Message);
+            }
+            PrintLine("Done.");
+        }
+
+        private async Task WarmupConnection()
+        {
+            PrintLine("Hitting home");
+            using (var client = new HttpClient())
+            {
+                var response = await client.GetAsync(_apiEndpoint);
+                if (!response.IsSuccessStatusCode)
+                {
+                    var errorMessage = "Request failed: " + (int) response.StatusCode + " " + response.ReasonPhrase;
+                    throw new Exception(errorMessage + Environment.NewLine + await response.Content.ReadAsStringAsync());
+                }
+            }
+            PrintLine("Success");
+        }
+
+        public async Task SendLoad(Func<string, RandomDataStreamContent> contentGenerator, int filesToAdd = 1)
+        {
+            using (var client = new HttpClient())
+            {
+                client.Timeout = TimeSpan.FromMinutes(20);
+                using (var form = new MultipartFormDataContent())
+                {
+                    form.Add(new StringContent("{\"section\" : \"This is a simple JSON content fragment\"}"), "metadata");
+                    for (var iter = 0; iter < filesToAdd; ++iter)
+                    {
+                        var fileName = Guid.NewGuid().ToString().ToLower();
+                        var fileContent = contentGenerator(fileName);
+                        form.Add(fileContent, "file", fileName);
+                    }
+
+                    var response = await client.PostAsync(_apiEndpoint + "api/upload", form);
+                    if (!response.IsSuccessStatusCode)
+                    {
+                        var errorMessage = "Upload failed: " + (int)response.StatusCode + " " + response.ReasonPhrase;
+                        throw new Exception(errorMessage + Environment.NewLine + await response.Content.ReadAsStringAsync());
+                    }
+                }
+            }
+        }
+
+        // Scenario 1: Small text part + large text part: 10MB/100MB/1GB [5:3:1]
+        private RandomDataStreamContent Scenario1FileContentGenerator(string fileName)
+        {
+            return FiveThreeOneChanceOfTenMegHundredMegOneGig(fileName, DataGenerationType.Text);
+        }
+
+        // Scenario 2: Small text part + large binary part: 10MB/100MB/1GB [5:3:1]
+        private RandomDataStreamContent Scenario2FileContentGenerator(string fileName)
+        {
+            return FiveThreeOneChanceOfTenMegHundredMegOneGig(fileName, DataGenerationType.Binary);
+        }
+
+        // Scenario 3: A number of large parts: text/binary [2:1] totalling more than 4GB (to test 32-bit limit)
+        private RandomDataStreamContent Scenario3FileContentGenerator(string fileName)
+        {
+            return TwoToOnceChanceOfTextVersusBinary(fileName, OneGigabyte);
+        }
+
+        // 10MB/100MB/1GB [5:3:1]
+        private RandomDataStreamContent FiveThreeOneChanceOfTenMegHundredMegOneGig(string fileName, DataGenerationType type)
+        {
+            // We do this by getting a random value between 0 and 8, and then deciding on size:
+            // 0 -> 10 MB
+            // 1 -> 10 MB
+            // 2 -> 10 MB
+            // 3 -> 10 MB
+            // 4 -> 10 MB
+            // 5 -> 100 MB
+            // 6 -> 100 MB
+            // 7 -> 100 MB
+            // 8 -> 1 GB
+
+            long fileSize;
+            var selector = Random.Next(0, 8);
+            if (selector <= 4)
+            {
+                fileSize = 10 * OneMegabyte;
+            }
+            else if (selector < 8)
+            {
+                fileSize = 100 * OneMegabyte;
+            }
+            else
+            {
+                fileSize = OneGigabyte;
+            }
+
+            return GenerateFileContent(fileName, fileSize, type);
+        }
+
+        // text/binary [2:1]
+        private RandomDataStreamContent TwoToOnceChanceOfTextVersusBinary(string fileName, long fileSize)
+        {
+            // We do this by getting a random value between 0 and 2, and then deciding on type:
+            // 0 -> Text
+            // 1 -> Text
+            // 2 -> Binary
+
+            return GenerateFileContent(fileName, fileSize, Random.Next(0, 2) < 2 ? DataGenerationType.Text : DataGenerationType.Binary);
+        }
+
+        private RandomDataStreamContent GenerateFileContent(string fileName, long fileSize, DataGenerationType type)
+        {
+            var fileContent = new RandomDataStreamContent(type, fileSize);
+            fileContent.Headers.ContentDisposition = new ContentDispositionHeaderValue("form-data")
+            {
+                Name = "\"files\"",
+                FileName = "\"" + fileName + "\""
+            };
+            var mediaType = type == DataGenerationType.Binary ? "application/octet-stream" : "text/plain";
+            fileContent.Headers.ContentType = new MediaTypeHeaderValue(mediaType);
+            return fileContent;
+        }
+
+        private static void PrintLine(string input, params object[] paramStrings)
+        {
+            Console.Write($"[{ DateTime.UtcNow.ToString(CultureInfo.InvariantCulture) }] ");
+            Console.WriteLine(input, paramStrings);
+        }
+    }
+}

--- a/testapp/MultipartPOST/MultipartPOSTClient/RandomDataStreamContent.cs
+++ b/testapp/MultipartPOST/MultipartPOSTClient/RandomDataStreamContent.cs
@@ -1,0 +1,145 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Runtime.CompilerServices;
+using System.Security.Authentication.ExtendedProtection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MultipartPostClient
+{
+    public enum DataGenerationType
+    {
+        Binary =    1 << 0,
+        Text =      1 << 1,
+    }
+
+    internal interface IDataGenerator
+    {
+        int Read(byte[] buffer, int offset, int count);
+    }
+
+    internal static class DataGeneratorFactory
+    {
+        private sealed class RandomBinaryDataGenerator : IDataGenerator
+        {
+            private byte _currentValue;
+            public int Read(byte[] buffer, int offset, int count)
+            {
+                for (var iter = 0; iter < buffer.Length; ++iter)
+                {
+                    buffer[iter] = _currentValue;
+                    _currentValue = (byte)((_currentValue + 1) % byte.MaxValue);
+                }
+                return count;
+            }
+        }
+
+        private sealed class RandomUtf8TextDataGenerator : IDataGenerator
+        {
+            private readonly byte[] _textSeed;
+            private int _currentByte;
+            public RandomUtf8TextDataGenerator()
+            {
+
+                _textSeed =
+                    Encoding.UTF8.GetBytes(
+                        "I'm afraid I still don't understand, sir. Mr. Crusher, ready a collision course with the Borg ship. Congratulations - you just destroyed the Enterprise. They were just sucked into space. Smooth as an android's bottom, eh, Data? Our neural pathways have become accustomed to your sensory input patterns. That might've been one of the shortest assignments in the history of Starfleet. You bet I'm agitated! I may be surrounded by insanity, but I am not insane. Some days you get the bear, and some days the bear gets you. Maybe if we felt any human loss as keenly as we feel one of those close to us, human history would be far less bloody. This is not about revenge. This is about justice. Is it my imagination, or have tempers become a little frayed on the ship lately? Well, I'll say this for him - he's sure of himself. Damage report! I recommend you don't fire until you're within 40,000 kilometers. Well, that's certainly good to know. The game's not big enough unless it scares you a little. Besides, you look good in a dress. What's a knock-out like you doing in a computer-generated gin joint like this? And blowing into maximum warp speed, you appeared for an instant to be in two places at once.");
+                _currentByte = 0;
+            }
+            public int Read(byte[] buffer, int offset, int count)
+            {
+                for (var iter = 0; iter < buffer.Length; ++iter)
+                {
+                    buffer[iter] = _textSeed[_currentByte];
+                    _currentByte = (_currentByte + 1) % _textSeed.Length;
+                }
+                return count;
+            }
+        }
+
+        public static IDataGenerator GetNewDataGenerator(DataGenerationType dataGenerationType)
+        {
+            switch (dataGenerationType)
+            {
+                case DataGenerationType.Binary:
+                    return new RandomBinaryDataGenerator();
+                case DataGenerationType.Text:
+                    return new RandomUtf8TextDataGenerator();
+                default:
+                    throw new InvalidOperationException(nameof(dataGenerationType));
+            }
+        }
+    }
+
+    public class RandomDataStreamContent : HttpContent
+    {
+        private const int DefaultBufferSize = 4096;
+        
+        private readonly int _bufferSize;
+        private readonly long _desiredLength;
+        private readonly Action<long> _progressUpdater;
+        private readonly IDataGenerator _generator;
+
+        public RandomDataStreamContent(DataGenerationType dataGenerationType, long desiredLength, Action<long> progressUpdater = null) :
+            this(dataGenerationType, desiredLength, DefaultBufferSize, progressUpdater) { }
+
+        public RandomDataStreamContent(DataGenerationType dataGenerationType, long desiredLength, int bufferSize, Action<long> progressUpdater = null)
+        {
+            if (bufferSize <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(bufferSize));
+            }
+            
+            _bufferSize = bufferSize;
+            _progressUpdater = progressUpdater;
+            _desiredLength = desiredLength;
+            _generator = DataGeneratorFactory.GetNewDataGenerator(dataGenerationType);
+        }
+
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)
+        {
+            return Task.Run(() =>
+            {
+                PrintLine("Serializing data");
+                var buffer = new byte[_bufferSize];
+                var uploaded = 0;
+                
+                while (uploaded < _desiredLength)
+                {
+                    var length = _generator.Read(buffer, 0, buffer.Length);
+                    if (length <= 0) break;
+
+                    uploaded += length;
+                    if (uploaded > _desiredLength)
+                    {
+                        var delta = (int)(uploaded - _desiredLength);
+                        uploaded -= delta;
+                        length -= delta;
+                    }
+
+                    stream.Write(buffer, 0, length);
+                    _progressUpdater?.Invoke(uploaded);
+                }
+                PrintLine($"Serialized { _desiredLength } bytes");
+            });
+        }
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = _desiredLength;
+            return true;
+        }
+
+        private void PrintLine(string input, params object[] paramStrings)
+        {
+            Console.Write($"[{ DateTime.UtcNow.ToString(CultureInfo.InvariantCulture) }] ");
+            Console.WriteLine(input, paramStrings);
+        }
+    }
+}

--- a/testapp/MultipartPOST/MultipartPOSTClient/project.json
+++ b/testapp/MultipartPOST/MultipartPOSTClient/project.json
@@ -1,0 +1,20 @@
+{
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "frameworks": {
+    "dnxcore50": {
+      "imports": "portable-net451+win8"
+    }
+  },
+  "dependencies": {
+    "Microsoft.AspNetCore.Mvc": "1.0.0-*",
+    "NETStandard.Library": "1.0.0-*",
+    "System.Net.Http": "4.0.1-*",
+    "System.Console": "4.0.0-*"
+  },
+  "commands": {
+    "run": "MultipartPOSTClient"
+  }
+}

--- a/testapp/MultipartPOST/README.md
+++ b/testapp/MultipartPOST/README.md
@@ -1,0 +1,45 @@
+##MultiPart Post
+MutipartPOST is a test that attempts to upload a set of very large files by means of a multipart POST message. It exercises three basic scenarios:
+
+```
+1. Small text part + large text part: 10MB/100MB/1GB [5:3:1]
+2. Small text part + large binary part: 10MB/100MB/1GB [5:3:1]
+3. A number of large parts: text/binary [2:1] totalling more than 4GB (to test 32-bit limit)
+```
+
+Additionally, it has the following characteristics:
+  * No-auth middleware scenario.
+  * All messages start with a small JSON text part.
+  * File payload is generated dynamically.
+
+##Components
+###Baseline
+Under directory `Baseline_DesktopCLR_MVC5_MultipartPOST` you can find a Windows-only baseline project that allows the client to upload large files. This baseline project uses MVC 5 and WebAPI 5 under the full desktop CLR. It exposes two endpoints:
+  * `~/`: where it displays a simple text message indicating the project is running. This is the "home" endpoint.
+  * `~/api/upload`: the actual upload endpoint, accepts POST messages with multipart content.
+The baseline project uses the stock multipart functionality that saves the files to disk before they can be processed by the server-side code.
+
+###MultipartPOST
+Under directory `MultipartPOST` you can find the server side of this test. It exposes two endpoints:
+  * `~/`: where it displays a simple text message indicating the project is running. This is the "home" endpoint.
+  * `~/api/upload`: the actual upload endpoint, accepts POST messages with multipart content.
+The MultipartPOST consumes the network stream into a buffer and then prints the number of bytes read.
+
+###MultipartPOSTClient
+Under directory `MultipartPOSTClient` you can find the client side of this test. It attempts to contact the home endpoint, and upon success it starts a number of iterations around scenarios 1, 2 and 3, as described above. Scenario 3 requires a large memory buffer that cannot be created under a 32-bit process, so scenario 3 only runs when the app is running in a 64-bit process.
+
+##How to run
+The most basic execution scenario can be done with the `runtest.ps1` PowerShell script. It simply starts the server and then runs the client to excercise all the scenarios.
+
+If you'd like to run it manually, you can:
+  1. Go to folder `MultipartPOST`
+  2. Execute: `dotnet restore`
+  3. Execute: `dotnet run`
+  4. Go to folder `MultipartPOSTClient`
+  5. Execute: `dotnet restore`
+  6. Execute: `dotnet run`
+
+If you want the client to hit the Baseline project, start the website and obtain the URL where it's exposed. If, for example, your baseline website is published under `http://localhost:28070/` you can then run the client with the following command:
+  1. Go to folder `MultipartPOSTClient`
+  2. Execute: `dotnet restore`
+  3. Execute: `dotnet run http://localhost:28070/`

--- a/testapp/MultipartPOST/runtest.ps1
+++ b/testapp/MultipartPOST/runtest.ps1
@@ -1,0 +1,7 @@
+cd MultipartPOST
+start dotnet run
+cd ..
+
+cd MultipartPOSTClient
+dotnet run
+cd ..


### PR DESCRIPTION
This is the first check-in of the large file multipart POST test. It attempts to upload a set of very large files by means of a multipart POST message. It exercises three basic scenarios:

```
1. Small text part + large text part: 10MB/100MB/1GB [5:3:1]
2. Small text part + large binary part: 10MB/100MB/1GB [5:3:1]
3. A number of large parts: text/binary [2:1] totalling more than 4GB (to test 32-bit limit)
```

Additionally, it has the following characteristics:
  * No-auth middleware scenario.
  * All messages start with a small JSON text part.
  * File payload is generated dynamically.

Under directory `Baseline_DesktopCLR_MVC5_MultipartPOST` you can find a Windows-only baseline project that allows the client to upload large files. This baseline project uses MVC 5 and WebAPI 5 under the full desktop CLR. It exposes two endpoints:
  * `~/`: where it displays a simple text message indicating the project is running. This is the "home" endpoint.
  * `~/api/upload`: the actual upload endpoint, accepts POST messages with multipart content.
The baseline project uses the stock multipart functionality that saves the files to disk before they can be processed by the server-side code.

Under directory `MultipartPOST` you can find the server side of this test. It exposes two endpoints:
  * `~/`: where it displays a simple text message indicating the project is running. This is the "home" endpoint.
  * `~/api/upload`: the actual upload endpoint, accepts POST messages with multipart content.
The MultipartPOST consumes the network stream into a buffer and then prints the number of bytes read.

Under directory `MultipartPOSTClient` you can find the client side of this test. It attempts to contact the home endpoint, and upon success it starts a number of iterations around scenarios 1, 2 and 3, as described above. Scenario 3 requires a large memory buffer that cannot be created under a 32-bit process, so scenario 3 only runs when the app is running in a 64-bit process.

The most basic execution scenario can be done with the `runtest.ps1` PowerShell script. It simply starts the server and then runs the client to excercise all the scenarios.

If you'd like to run it manually, you can:
  1. Go to folder `MultipartPOST`
  2. Execute: `dotnet restore`
  3. Execute: `dotnet run`
  4. Go to folder `MultipartPOSTClient`
  5. Execute: `dotnet restore`
  6. Execute: `dotnet run`

If you want the client to hit the Baseline project, start the website and obtain the URL where it's exposed. If, for example, your baseline website is published under `http://localhost:28070/` you can then run the client with the following command:
  1. Go to folder `MultipartPOSTClient`
  2. Execute: `dotnet restore`
  3. Execute: `dotnet run http://localhost:28070/`

This commit resolves #58.