### PR TITLE
Provide a host option to enable HTTPS on Kestrel only when needed

### DIFF
--- a/testapp/StressMvc/Startup.cs
+++ b/testapp/StressMvc/Startup.cs
@@ -116,7 +116,17 @@ namespace StarterMvc
                     //options.ThreadCount = 4;
                     //options.NoDelay = true;
                     //options.UseConnectionLogging();
-                    options.UseHttps(_httpsCertFile, _httpsCertPwd);
+                    try
+                    {
+                        if (Boolean.Parse(config["SecurityOption:EnableHTTPS"]) == true)
+                        {
+                            Console.WriteLine("Enabled HTTPS");
+                            options.UseHttps(_httpsCertFile, _httpsCertPwd);
+                        }
+                    }
+                    catch (Exception) //Ignore if the option is not provided.
+                    {
+                    }
                 })
                 .UseConfiguration(config)
                 .UseIISIntegration()

--- a/testapp/StressMvc/hosting.json
+++ b/testapp/StressMvc/hosting.json
@@ -1,0 +1,5 @@
+﻿{
+  "SecurityOption": {
+    "EnableHTTPS": false
+  }
+}

--- a/testapp/StressMvc/project.json
+++ b/testapp/StressMvc/project.json
@@ -13,6 +13,7 @@
     "copyToOutput": {
       "include": [
         "appsettings.json",
+        "hosting.json",
         "stressmvc.pfx",
         "Views",
         "wwwroot"
@@ -68,6 +69,7 @@
     ],
     "include": [
       "appsettings.json",
+      "hosting.json",
       "stressmvc.pfx",
       "Views",
       "wwwroot"


### PR DESCRIPTION
If the app is started with aspcoremodule from IIS, it's likely to be started with an build-in account (like apppoolidentity, local system, network system). However it seems enabling HTTPS on Kestrel needs to access resources requiring admin privilege. It would fail to start with the build-in identity.

Provide an option to start HTTPS only when needed (mostly standalone case).