### PR TITLE
Bump test projects up to .NET 4.5.2

### DIFF
--- a/Performance.sln
+++ b/Performance.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26208.0
+VisualStudioVersion = 15.0.26217.2
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{39290E57-4492-4F65-89D6-64C95DE73976}"
 EndProject
@@ -37,13 +37,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Model", "Model", "{5FA83898
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "MultipartPOST", "MultipartPOST", "{4360A0FB-7357-4CB4-9B0F-ED71E71B1077}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AspNetCore.Tests.Performance", "test\Microsoft.AspNetCore.Tests.Performance\Microsoft.AspNetCore.Tests.Performance.csproj", "{76C8FD9D-615A-4741-8E03-A11F7C20A99F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Tests.Performance", "test\Microsoft.AspNetCore.Tests.Performance\Microsoft.AspNetCore.Tests.Performance.csproj", "{76C8FD9D-615A-4741-8E03-A11F7C20A99F}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StarterMvc", "testapp\StarterMvc\StarterMvc.csproj", "{8397CB65-B60F-4881-B0A1-E881593A487C}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Benchmarks.Framework", "src\Benchmarks.Framework\Benchmarks.Framework.csproj", "{488D79ED-7138-4CCB-9A9F-458FA4A076A8}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microbenchmarks.Tests", "test\Microbenchmarks.Tests\Microbenchmarks.Tests.csproj", "{9B73D4A3-CA9D-4396-8000-F69E9B0EB9D3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microbenchmarks.Tests", "test\Microbenchmarks.Tests\Microbenchmarks.Tests.csproj", "{9B73D4A3-CA9D-4396-8000-F69E9B0EB9D3}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Benchmarks.Utility", "src\Benchmarks.Utility\Benchmarks.Utility.csproj", "{65DCA477-590C-4453-B688-7BBD057B2C6F}"
 EndProject
@@ -51,7 +51,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PerformanceDashboard", "das
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Stress.Framework", "src\Stress.Framework\Stress.Framework.csproj", "{0B2EC639-4697-4854-9512-122B1ACD6253}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AspNetCore.Tests.Stress", "stress-test\Microsoft.AspNetCore.Tests.Stress\Microsoft.AspNetCore.Tests.Stress.csproj", "{67CEE842-1B97-4663-A509-1F18A86F9A5F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Tests.Stress", "stress-test\Microsoft.AspNetCore.Tests.Stress\Microsoft.AspNetCore.Tests.Stress.csproj", "{67CEE842-1B97-4663-A509-1F18A86F9A5F}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HelloWorldMvc", "testapp\HelloWorldMvc\HelloWorldMvc.csproj", "{E5D2EE3F-672A-41A5-9B0B-0A979E333920}"
 EndProject
@@ -81,7 +81,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LocalizedViews", "testapp\L
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RazorCodeGenerator", "testapp\RazorCodeGenerator\RazorCodeGenerator.csproj", "{0236230D-D34D-4546-9221-E5767F19ED9E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestApp.Test", "test\TestApp.Test\TestApp.Test.csproj", "{82B767A5-1640-4561-9F04-2E90AD0BDEFB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestApp.Test", "test\TestApp.Test\TestApp.Test.csproj", "{82B767A5-1640-4561-9F04-2E90AD0BDEFB}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PooledKestrel", "testapp\PooledKestrel\PooledKestrel.csproj", "{F14C584D-3175-43B8-996F-59046629CD27}"
 EndProject

--- a/src/Benchmarks.Framework/BenchmarkTestCaseRunner.cs
+++ b/src/Benchmarks.Framework/BenchmarkTestCaseRunner.cs
@@ -8,7 +8,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Benchmarks.Framework.BenchmarkPersistence;
-#if !NET451
+#if !NET452
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.PlatformAbstractions;
 #endif
@@ -133,7 +133,7 @@ namespace Benchmarks.Framework
 
         private static string GetMachineName()
         {
-#if NET451
+#if NET452
             return Environment.MachineName;
 #else
             var config = new ConfigurationBuilder()

--- a/src/Benchmarks.Framework/Benchmarks.Framework.csproj
+++ b/src/Benchmarks.Framework/Benchmarks.Framework.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp1.1</TargetFrameworks>
     <RuntimeIdentifier Condition=" '$(TargetFramework)' != 'netcoreapp1.1' ">win7-x64</RuntimeIdentifier>
   </PropertyGroup>
 

--- a/src/Benchmarks.Utility/Benchmarks.Utility.csproj
+++ b/src/Benchmarks.Utility/Benchmarks.Utility.csproj
@@ -2,7 +2,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net451;netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp1.1</TargetFrameworks>
     <RuntimeIdentifier Condition=" '$(TargetFramework)' != 'netcoreapp1.1' ">win7-x64</RuntimeIdentifier>
   </PropertyGroup>
 
@@ -16,7 +17,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.2.0-*" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <PackageReference Include="System.Net.Http" Version="$(CoreFxVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Benchmarks.Utility/Helpers/DotnetHelper.cs
+++ b/src/Benchmarks.Utility/Helpers/DotnetHelper.cs
@@ -49,17 +49,19 @@ namespace Benchmarks.Utility.Helpers
 
         public bool Publish(string workingDir, string outputDir, string framework, bool useShellExecute = false)
         {
+            if (string.IsNullOrEmpty(framework))
+            {
+                // Provide required argument where multiple targets are supported.
+                // All test sites support .NET Core App on every platform.
+                framework = "netcoreapp1.1";
+            }
+
             var psi = new ProcessStartInfo(GetDotnetExecutable())
             {
-                Arguments = $"publish --output \"{outputDir}\"",
+                Arguments = $"publish --output \"{outputDir}\" --framework {framework}",
                 WorkingDirectory = workingDir,
                 UseShellExecute = useShellExecute
             };
-
-            if (!string.IsNullOrEmpty(framework))
-            {
-                psi.Arguments = $"{psi.Arguments} --framework {framework}";
-            }
 
             var proc = Process.Start(psi);
             var exited = proc.WaitForExit((int)TimeSpan.FromMinutes(5).TotalMilliseconds);

--- a/src/Benchmarks.Utility/Helpers/IISTestManager.cs
+++ b/src/Benchmarks.Utility/Helpers/IISTestManager.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if NET451
+#if NET452
 
 using System;
 using System.Collections.Generic;
@@ -13,7 +13,7 @@ namespace Benchmarks.Utility.Helpers
     /// <summary>
     /// Test manager helps test cases to deploy a web project to IIS.
     ///
-    /// This class depends on IISDeployer of Microsoft.AspNetCore.Server.IntegrationTesting package which is NET451 only.
+    /// This class depends on IISDeployer of Microsoft.AspNetCore.Server.IntegrationTesting package which is NET452 only.
     /// https://github.com/aspnet/Hosting/tree/dev/src/Microsoft.AspNetCore.Server.IntegrationTesting
     /// </summary>
     public class IISTestManager : IDisposable

--- a/src/Stress.Framework/Stress.Framework.csproj
+++ b/src/Stress.Framework/Stress.Framework.csproj
@@ -2,7 +2,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp1.1</TargetFrameworks>
     <RuntimeIdentifier Condition=" '$(TargetFramework)' != 'netcoreapp1.1' ">win7-x64</RuntimeIdentifier>
   </PropertyGroup>
 

--- a/src/Stress.Framework/Stress.Framework.csproj
+++ b/src/Stress.Framework/Stress.Framework.csproj
@@ -16,6 +16,6 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="1.2.0-*" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.2.0-*" />
     <PackageReference Include="Microsoft.Extensions.RuntimeEnvironment.Sources" Version="1.2.0-*" PrivateAssets="All" />
-    <PackageReference Include="xunit.runner.reporters" Version="2.2.0-beta5-build3474" />
+    <PackageReference Include="xunit.runner.reporters" Version="2.2.0-*" />
   </ItemGroup>
 </Project>

--- a/src/Stress.Framework/StressTestCaseRunner.cs
+++ b/src/Stress.Framework/StressTestCaseRunner.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-#if !NET451
+#if !NET452
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.PlatformAbstractions;
 #endif
@@ -136,7 +136,7 @@ namespace Stress.Framework
 
         private static string GetMachineName()
         {
-#if NET451
+#if NET452
             return Environment.MachineName;
 #else
             var config = new ConfigurationBuilder()

--- a/stress-test/Microsoft.AspNetCore.Tests.Stress/Microsoft.AspNetCore.Tests.Stress.csproj
+++ b/stress-test/Microsoft.AspNetCore.Tests.Stress/Microsoft.AspNetCore.Tests.Stress.csproj
@@ -2,7 +2,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net451;netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp1.1</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <RuntimeIdentifier Condition=" '$(TargetFramework)' != 'netcoreapp1.1' ">win7-x64</RuntimeIdentifier>
   </PropertyGroup>

--- a/test/Microbenchmarks.Tests/Microbenchmarks.Tests.csproj
+++ b/test/Microbenchmarks.Tests/Microbenchmarks.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp1.1</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <RuntimeIdentifier Condition=" '$(TargetFramework)' != 'netcoreapp1.1' ">win7-x64</RuntimeIdentifier>

--- a/test/Microsoft.AspNetCore.Tests.Performance/AntaresStartup.cs
+++ b/test/Microsoft.AspNetCore.Tests.Performance/AntaresStartup.cs
@@ -9,11 +9,11 @@ using Benchmarks.Framework;
 using Benchmarks.Framework.BenchmarkPersistence;
 using Benchmarks.Utility.Azure;
 using Benchmarks.Utility.Helpers;
-#if !NET451
+#if !NET452
 using Microsoft.Extensions.Configuration;
 #endif
 using Microsoft.Extensions.Logging;
-#if !NET451
+#if !NET452
 using Microsoft.Extensions.PlatformAbstractions;
 #endif
 using Xunit;
@@ -221,7 +221,7 @@ namespace Microsoft.AspNetCore.Tests.Performance
 
         private static string GetMachineName()
         {
-#if NET451
+#if NET452
             return Environment.MachineName;
 #else
             var config = new ConfigurationBuilder()

--- a/test/Microsoft.AspNetCore.Tests.Performance/Microsoft.AspNetCore.Tests.Performance.csproj
+++ b/test/Microsoft.AspNetCore.Tests.Performance/Microsoft.AspNetCore.Tests.Performance.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp1.1</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <RuntimeIdentifier Condition=" '$(TargetFramework)' != 'netcoreapp1.1' ">win7-x64</RuntimeIdentifier>

--- a/test/Microsoft.AspNetCore.Tests.Performance/WebIISPerformance.cs
+++ b/test/Microsoft.AspNetCore.Tests.Performance/WebIISPerformance.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if NET451
+#if NET452
 
 using System;
 using System.Net.Http;

--- a/test/Microsoft.AspNetCore.Tests.Performance/WebPerformance.cs
+++ b/test/Microsoft.AspNetCore.Tests.Performance/WebPerformance.cs
@@ -53,11 +53,11 @@ namespace Microsoft.AspNetCore.Tests.Performance
         public void Production_DotNet_Startup(string sampleName)
         {
             var framework = Microsoft.Extensions.Internal.RuntimeEnvironment.RuntimeType;
-            var appliationFramework = GetFrameworkName(framework);
+            var applicationFramework = GetFrameworkName(framework);
             var testName = $"{sampleName}.{framework}.{nameof(Production_DotNet_Startup)}";
             var logger = LogUtility.LoggerFactory.CreateLogger(testName);
 
-            var testProject = _sampleManager.GetDotNetPublishedSample(sampleName, appliationFramework);
+            var testProject = _sampleManager.GetDotNetPublishedSample(sampleName, applicationFramework);
             Assert.True(testProject != null, $"Fail to set up test project.");
             logger.LogInformation($"Test project is set up at {testProject}");
 


### PR DESCRIPTION
- aspnet/Testing#248
- xUnit no longer supports .NET 4.5.1
- build tests for desktop .NET only on Windows

Revert previous workaround for xUnit change.