### PR TITLE
Replace stress test targets with repo.targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ packages/
 artifacts/
 PublishProfiles/
 .vs/
+.vscode/
 bower_components/
 node_modules/
 **/wwwroot/lib/

--- a/build/common.props
+++ b/build/common.props
@@ -1,12 +1,11 @@
 <Project>
+  <Import Project="dependencies.props" />
   <Import Project="..\version.props" />
 
   <PropertyGroup>
     <Product>Microsoft ASP.NET Core</Product>
     <RepositoryUrl>https://github.com/aspnet/Performance</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <NetCoreAppImplicitPackageVersion>1.2.0-*</NetCoreAppImplicitPackageVersion>
-    <NetStandardImplicitPackageVersion>1.6.2-*</NetStandardImplicitPackageVersion>
     <VersionSuffix Condition="'$(VersionSuffix)'!='' AND '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
   </PropertyGroup>
 

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <CoreFxVersion>4.3.0</CoreFxVersion>
+    <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
+  </PropertyGroup>
+</Project>

--- a/build/repo.props
+++ b/build/repo.props
@@ -1,0 +1,5 @@
+<Project>
+  <ItemGroup>
+    <ExcludeFromTest Include="$(RepositoryRoot)test\Microsoft.AspNetCore.Tests.Throughput\*.csproj" />
+  </ItemGroup>
+</Project>

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -1,0 +1,10 @@
+<Project>
+  <Target Name="_ResolveStressTestProjects">
+    <ItemGroup>
+      <ProjectsToTest Remove="@(ProjectsToTest)" />
+      <ProjectsToTest Include="$(RepositoryRoot)stress-test\*\*.csproj" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="StressTest" DependsOnTargets="_ResolveStressTestProjects;TestProjects" />
+</Project>

--- a/makefile.shade
+++ b/makefile.shade
@@ -1,37 +1,7 @@
-
-var BASE_DIR='${Directory.GetCurrentDirectory()}'
-var VERSION='0.1'
-var FULL_VERSION='0.1'
-var AUTHORS='Microsoft Open Technologies, Inc.'
-var PREVIOUS_NO_PARALLEL_TEST_PROJECTS='${E("NO_PARALLEL_TEST_PROJECTS")}'
-var SAMPLES_PROJECT_GLOB = '${new[] { "dashboard/*/*.csproj", "stress-test/*/*.csproj", "testapp/*/*.csproj", "testapp/*/*/*.csproj" }}'
-
 use-standard-lifecycle
 k-standard-goals
 
-#repo-initialize-more .repo-initialize target='initialize'
-  use-volatile-feed
+#stress-test
   @{
-    // workaround https://github.com/Microsoft/msbuild/issues/1587
-    if (!NoRestore)
-    {
-      Dotnet("msbuild \"" + Path.Combine(BASE_DIR, "build/restore.more.proj") + "\"");
-    }
-  }
-
-#stress-test .compile
-  @{
-    var projectFiles = Files.Include("stress-test/**/*.csproj").Exclude("**/bin/**/*").ToList();
-
-    projectFiles.ForEach(projectFile =>
-    {
-      var projectFolder = Path.GetDirectoryName(projectFile);
-      var projectName = Path.GetFileName(projectFolder);
-      E("NO_PARALLEL_TEST_PROJECTS", projectName);
-
-      var configuration = "Debug";
-      DotnetTest(projectFile, configuration, E("KOREBUILD_DOTNET_TEST_OPTIONS"));
-    });
-
-    E("NO_PARALLEL_TEST_PROJECTS", PREVIOUS_NO_PARALLEL_TEST_PROJECTS);
+    MSBuild("/t:StressTest");
   }

--- a/src/Benchmarks.Utility/Benchmarks.Utility.csproj
+++ b/src/Benchmarks.Utility/Benchmarks.Utility.csproj
@@ -17,6 +17,6 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <PackageReference Include="System.Net.Http" Version="4.4.0-*" />
+    <PackageReference Include="System.Net.Http" Version="$(CoreFxVersion)" />
   </ItemGroup>
 </Project>

--- a/test/Microbenchmarks.Tests/Microbenchmarks.Tests.csproj
+++ b/test/Microbenchmarks.Tests/Microbenchmarks.Tests.csproj
@@ -3,6 +3,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp1.1</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <RuntimeIdentifier Condition=" '$(TargetFramework)' != 'netcoreapp1.1' ">win7-x64</RuntimeIdentifier>
   </PropertyGroup>

--- a/test/Microbenchmarks.Tests/RazorTests.cs
+++ b/test/Microbenchmarks.Tests/RazorTests.cs
@@ -63,7 +63,7 @@ namespace Microbenchmarks.Tests.Razor
         public void ViewParsing(bool designTime)
         {
             // Arrange
-            var services = ConfigureDefaultServices(Environment.CurrentDirectory);
+            var services = ConfigureDefaultServices(Directory.GetCurrentDirectory());
             var compilationService = (RazorCompilationService)services.GetRequiredService<IRazorCompilationService>();
 
             var assembly = typeof(RazorTests).GetTypeInfo().Assembly;

--- a/test/Microsoft.AspNetCore.Tests.Performance/Microsoft.AspNetCore.Tests.Performance.csproj
+++ b/test/Microsoft.AspNetCore.Tests.Performance/Microsoft.AspNetCore.Tests.Performance.csproj
@@ -3,6 +3,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp1.1</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <RuntimeIdentifier Condition=" '$(TargetFramework)' != 'netcoreapp1.1' ">win7-x64</RuntimeIdentifier>
   </PropertyGroup>

--- a/test/Microsoft.AspNetCore.Tests.Throughput/.notest
+++ b/test/Microsoft.AspNetCore.Tests.Throughput/.notest
@@ -1,2 +1,0 @@
-// This file is a feature of KoreBuild that prevents tests from running in this directory. Tests in this project
-// require setup as well as "client.names", "password_file", "server.name", and "username" settings in the environment.

--- a/test/Microsoft.AspNetCore.Tests.Throughput/README.txt
+++ b/test/Microsoft.AspNetCore.Tests.Throughput/README.txt
@@ -1,0 +1,2 @@
+The tests in this project are not run by default from the build.cmd script.
+This project require setup as well as "client.names", "password_file", "server.name", and "username" settings in the environment.

--- a/testapp/BasicApi/BasicApi.csproj
+++ b/testapp/BasicApi/BasicApi.csproj
@@ -23,4 +23,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.2.0-*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.2.0-*" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.1'">
+    <PackageReference Include="System.Security.Cryptography.Csp" Version="$(CoreFxVersion)" />
+  </ItemGroup>
 </Project>

--- a/testapp/LargeJsonApi/LargeJsonApiClient/LargeJsonApiClient.csproj
+++ b/testapp/LargeJsonApi/LargeJsonApiClient/LargeJsonApiClient.csproj
@@ -18,6 +18,6 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <PackageReference Include="System.Net.Http" Version="4.4.0-*" />
+    <PackageReference Include="System.Net.Http" Version="$(CoreFxVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Remove workarounds from makefile.shade.
Implements stress test in repo.targets.

Note: leaves the makefile as a shim into calling MSBuild. This will be unnecessary once aspnet/Korebuild#174 is resolved.