### PR TITLE
Update to current NETStandard.Library version

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)'=='.NETFramework' AND '$(OutputType)'=='library'">
-    <PackageReference Include="NETStandard.Library" Version="$(NetStandardImplicitPackageVersion)" />
+    <PackageReference Include="NETStandard.Library" Version="$(BundledNETStandardPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -5,7 +5,6 @@
     <CoreFxVersion>4.3.0</CoreFxVersion>
     <InternalAspNetCoreSdkVersion>2.0.0-*</InternalAspNetCoreSdkVersion>
     <JsonNetVersion>10.0.1</JsonNetVersion>
-    <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
     <PlatformAbstractionsVersion>1.2.0-*</PlatformAbstractionsVersion>
     <RuntimeFrameworkVersion>2.0.0-*</RuntimeFrameworkVersion>
     <SystemNetHttpVersion>4.3.1</SystemNetHttpVersion>

--- a/src/Benchmarks.Utility/Helpers/DotnetHelper.cs
+++ b/src/Benchmarks.Utility/Helpers/DotnetHelper.cs
@@ -22,28 +22,24 @@ namespace Benchmarks.Utility.Helpers
         {
         }
 
-        public ProcessStartInfo BuildStartInfo(
-            string appbasePath,
-            string argument)
+        public ProcessStartInfo BuildStartInfo(string appbasePath, string arguments)
         {
             var dotnetPath = GetDotnetExecutable();
-            var psi = new ProcessStartInfo(dotnetPath, argument)
+            var psi = new ProcessStartInfo(dotnetPath, arguments)
             {
                 WorkingDirectory = appbasePath,
-                UseShellExecute = _dotnetAppName.Equals(dotnetPath)
             };
 
             return psi;
         }
 
-        public bool Restore(string workingDir, bool quiet = false, bool useShellExecute = false)
+        public bool Restore(string workingDir, bool quiet = false)
         {
             var dotnet = GetDotnetExecutable();
             var psi = new ProcessStartInfo(dotnet)
             {
                 Arguments = "restore" + (quiet ? " --verbosity minimal" : string.Empty),
                 WorkingDirectory = workingDir,
-                UseShellExecute = useShellExecute
             };
 
             var proc = Process.Start(psi);
@@ -53,7 +49,7 @@ namespace Benchmarks.Utility.Helpers
             return exited && proc.ExitCode == 0;
         }
 
-        public bool Publish(string workingDir, string outputDir, string framework, bool useShellExecute = false)
+        public bool Publish(string workingDir, string outputDir, string framework)
         {
             if (string.IsNullOrEmpty(framework))
             {
@@ -67,7 +63,6 @@ namespace Benchmarks.Utility.Helpers
             {
                 Arguments = $"publish --output \"{outputDir}\" --framework {framework}",
                 WorkingDirectory = workingDir,
-                UseShellExecute = useShellExecute
             };
 
             var proc = Process.Start(psi);

--- a/version.props
+++ b/version.props
@@ -2,6 +2,6 @@
 <Project>
   <PropertyGroup>
     <VersionPrefix>2.0.0</VersionPrefix>
-    <VersionSuffix>preview1</VersionSuffix>
+    <VersionSuffix>preview2</VersionSuffix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
- cleans up lots of package downgrade warnings
- oddly, `ProcessStartInfo.UseShellExecute == true` is no longer supported
  - fortunately, not used much