### PR TITLE
Update to latext xUnit

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -5,7 +5,7 @@
     <CoreFxVersion>4.3.0</CoreFxVersion>
     <InternalAspNetCoreSdkVersion>2.0.0-*</InternalAspNetCoreSdkVersion>
     <JsonNetVersion>10.0.1</JsonNetVersion>
-    <TestSdkVersion>15.0.0</TestSdkVersion>
-    <XunitVersion>2.2.0</XunitVersion>
+    <TestSdkVersion>15.3.0-*</TestSdkVersion>
+    <XunitVersion>2.3.0-beta2-*</XunitVersion>
   </PropertyGroup>
 </Project>

--- a/src/Benchmarks.Framework/BenchmarkTestCaseBase.cs
+++ b/src/Benchmarks.Framework/BenchmarkTestCaseBase.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
-using NullMessageSink = Xunit.Sdk.NullMessageSink;
 using TestMethodDisplay = Xunit.Sdk.TestMethodDisplay;
 
 namespace Benchmarks.Framework
@@ -22,9 +21,6 @@ namespace Benchmarks.Framework
         [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
         protected BenchmarkTestCaseBase()
         {
-            // No way for us to get access to the message sink on the execution de-serialization path.
-            // Fortunately, have reported errors during discovery.
-            DiagnosticMessageSink = new NullMessageSink();
         }
 
         public BenchmarkTestCaseBase(
@@ -42,8 +38,6 @@ namespace Benchmarks.Framework
 
             TestMethodName = name;
             DisplayName = $"{name} [Variation: {variation}]";
-
-            DiagnosticMessageSink = diagnosticMessageSink;
             Variation = variation;
 
             var potentialMetricCollector = testMethod.Method.GetParameters().FirstOrDefault();
@@ -63,8 +57,6 @@ namespace Benchmarks.Framework
                 TestMethodArguments = testMethodArguments;
             }
         }
-
-        protected IMessageSink DiagnosticMessageSink { get; }
 
         public abstract IMetricCollector MetricCollector { get; }
 

--- a/src/Stress.Framework/StressTestCaseBase.cs
+++ b/src/Stress.Framework/StressTestCaseBase.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.Server.IntegrationTesting;
 using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
-using NullMessageSink = Xunit.Sdk.NullMessageSink;
 using TestMethodDisplay = Xunit.Sdk.TestMethodDisplay;
 
 namespace Stress.Framework
@@ -19,9 +18,6 @@ namespace Stress.Framework
         [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
         protected StressTestCaseBase()
         {
-            // No way for us to get access to the message sink on the execution de-serialization path.
-            // Fortunately, have reported errors during discovery.
-            DiagnosticMessageSink = new NullMessageSink();
         }
 
         public StressTestCaseBase(
@@ -41,14 +37,10 @@ namespace Stress.Framework
             TestMethodName = name;
             WarmupMethod = warmupMethod;
             DisplayName = name;
-
-            DiagnosticMessageSink = diagnosticMessageSink;
             ServerType = serverType;
         }
 
         public string TestApplicationName { get; private set; }
-
-        protected IMessageSink DiagnosticMessageSink { get; private set; }
 
         public abstract IStressMetricCollector MetricCollector { get; }
 

--- a/stress-test/Microsoft.AspNetCore.Tests.Stress/Microsoft.AspNetCore.Tests.Stress.csproj
+++ b/stress-test/Microsoft.AspNetCore.Tests.Stress/Microsoft.AspNetCore.Tests.Stress.csproj
@@ -4,6 +4,9 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <PreserveCompilationContext>true</PreserveCompilationContext>
+
+    <!-- Allow public warm-up methods. -->
+    <NoWarn>$(NoWarn);xUnit1013</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.AspNetCore.Tests.Performance/Microsoft.AspNetCore.Tests.Performance.csproj
+++ b/test/Microsoft.AspNetCore.Tests.Performance/Microsoft.AspNetCore.Tests.Performance.csproj
@@ -4,6 +4,9 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <PreserveCompilationContext>true</PreserveCompilationContext>
+
+    <!-- Allow skipped tests and let [Benchmark] tests have data. -->
+    <NoWarn>$(NoWarn);xUnit1004;xUnit1005</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- handle breaking change in `XunitTestCase`; remove `DiagnosticMessageSink` properties
- ignore new xUnit compilation errors